### PR TITLE
Optimize heatmaps and remove usage of disp_val

### DIFF
--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
@@ -103,9 +103,6 @@ public:
 	// Orientation unit vector for an entity
 	FORCEINLINE static FTelemetryProperty Orientation(const FVector &Vec) { return FTelemetryProperty(TEXT("dir"), Vec); }
 
-	// The name of the value the visualizer will use
-	FORCEINLINE static FTelemetryProperty DisplayValue(const FString &Value) { return FTelemetryProperty("disp_val", Value); }
-
 	// Timestamp of the event using the client's clock by default
 	FORCEINLINE static FTelemetryProperty ClientTimestamp(const FDateTime &Value = FDateTime::UtcNow()) { return FTelemetryProperty("client_ts", Value); }
 

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
@@ -85,6 +85,7 @@ public:
 	}
 
 	// Singleton reference
+	// Ensure Initialize is called before this is used
 	static FTelemetryManager &Get() { check(Instance.IsValid()) return *Instance; }
 
 	// Get the currently set client id

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
@@ -63,7 +63,7 @@ public:
 
 	//Value for an event
 	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Value"))
-    float value;
+	TMap<FString, FString> values;
 
 	//Session of the event
 	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Session ID"))
@@ -92,7 +92,7 @@ public:
 	void SetScale(float inScale);
 
 	//Set the value and range
-	void SetValue(float inValue) { value = inValue; }
+	void AddValue(FString name, FString value) { values.Add(name, value); }
 
 	//Return the private name or category
 	FString GetName() { return name; }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
@@ -165,7 +165,6 @@ void ATelemetryEvent::SetEvent(const TSharedPtr<STelemetryEvent> inPointer)
 	if (InstanceTypes.Num() != 1) return;
 
 	time = inPointer->time;
-	value = inPointer->value;
 	location = inPointer->point;
 	session = inPointer->session;
 	orientation = inPointer->orientation;
@@ -173,6 +172,11 @@ void ATelemetryEvent::SetEvent(const TSharedPtr<STelemetryEvent> inPointer)
 	build = inPointer->build;
 	name = inPointer->name;
 	category = inPointer->category;
+
+	for (auto& value : inPointer->values)
+	{
+		values.Add(value.Key, value.Value->AsString());
+	}
 
 	eventName = category + L" " + name;
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
@@ -916,6 +916,24 @@ void FTelemetryVisualizerUI::GenerateEventBox()
 	}
 }
 
+void FTelemetryVisualizerUI::GenerateSubEventBox(int index)
+{
+	m_eventgroupSubList.Empty();
+	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+	m_subVizSelection = m_eventgroupSubList[0];
+
+	for (auto& name : m_queryEventCollection[index].attributeNames)
+	{
+		m_eventgroupSubList.Add(MakeShareable<FString>(new FString(name)));
+	}
+
+	if (m_subVizSelection.IsValid())
+	{
+		m_vizSubChoice->SetSelectedItem(m_eventgroupSubList[0]);
+		m_vizSubChoice->RefreshOptions();
+	}
+}
+
 FReply FTelemetryVisualizerUI::SelectAll()
 {
 	for (int i = 0; i < m_filterCollection.Num(); i++)

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTab.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTab.cpp
@@ -358,6 +358,42 @@ TSharedRef<SDockTab> FTelemetryVisualizerUI::SpawnVizTab(const FSpawnTabArgs& Ta
 						.VAlign(VAlign_Fill)
 						.Padding(40.f, 10.f, 40.f, 5.f)
 					[
+						//Event to act on
+						SNew(SHorizontalBox)
+						+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.Padding(2.f, 0.f, 0.f, 0.f)
+							.VAlign(VAlign_Center)
+							.HAlign(HAlign_Fill)
+						[
+							SNew(SBox)
+								.WidthOverride(90.f)
+							[
+								SNew(STextBlock).Text(LOCTEXT("Values", "Values"))
+							]
+						]
+						+ SHorizontalBox::Slot()
+							.Padding(2.f, 0.f, 0.f, 0.f)
+							.VAlign(VAlign_Center)
+							.HAlign(HAlign_Fill)
+						[
+							SAssignNew(m_vizSubChoice, SComboBox<TSharedPtr<FString>>)
+								.OptionsSource(&m_eventgroupSubList)
+								.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnSubVizSelectionChanged)
+								.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+								.InitiallySelectedItem(m_subVizSelection)
+							[
+								SNew(STextBlock)
+									.Text_Raw(this, &FTelemetryVisualizerUI::GetCurrentSubVizItem)
+							]
+						]
+					]
+					+ SVerticalBox::Slot()
+						.AutoHeight()
+						.HAlign(HAlign_Fill)
+						.VAlign(VAlign_Fill)
+						.Padding(40.f, 5.f, 40.f, 5.f)
+					[
 						SNew(SHorizontalBox)
 						+ SHorizontalBox::Slot()
 							.AutoWidth()
@@ -673,6 +709,11 @@ FText FTelemetryVisualizerUI::GetCurrentVizItem() const
 	return FText::FromString(*m_vizSelection);
 }
 
+FText FTelemetryVisualizerUI::GetCurrentSubVizItem() const
+{
+	return FText::FromString(*m_subVizSelection);
+}
+
 void FTelemetryVisualizerUI::OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
 {
 	if (NewValue.IsValid())
@@ -689,6 +730,7 @@ void FTelemetryVisualizerUI::OnVizSelectionChanged(TSharedPtr<FString> NewValue,
 			if (m_queryEventCollection[i].name == *NewValue)
 			{
 				m_anim_Control.UpdateContainer(&m_queryEventCollection[i]);
+				GenerateSubEventBox(i);
 			}
 		}
 
@@ -705,6 +747,16 @@ void FTelemetryVisualizerUI::OnVizSelectionChanged(TSharedPtr<FString> NewValue,
 			FTimespan totalTime = m_anim_Control.GetTimespan();
 			m_animationTotalTime->SetText(FText::Format(FTextFormat::FromString("{0}:{1}"), FText::AsNumber(totalTime.GetMinutes()), FText::AsNumber(totalTime.GetSeconds(), &format)));
 		}
+	}
+}
+
+void FTelemetryVisualizerUI::OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
+{
+	if (NewValue.IsValid())
+	{
+		ResetRange();
+
+		m_subVizSelection = NewValue;
 	}
 }
 
@@ -934,7 +986,7 @@ FReply FTelemetryVisualizerUI::GenerateHeatmap(SEventEditorContainer* collection
 	DestroyActors();
 	UWorld* currentTarget = GetLocalWorld();
 
-	if (currentTarget != nullptr && collection != nullptr)
+	if (currentTarget != nullptr && collection != nullptr && *m_subVizSelection != "")
 	{
 		if ((first == 0 && first == last) || (first == collection->events.Num() - 1 && first == last))
 		{
@@ -943,141 +995,130 @@ FReply FTelemetryVisualizerUI::GenerateHeatmap(SEventEditorContainer* collection
 		}
 
 		//Segment the world in to blocks of the specified size encompassing all points
-		FBox range = collection->GetPointRange(first, last);
-		float extent = m_heatmapSize / 2;
-		FVector extents(extent, extent, extent);
-		TArray<FBox> parts;
+		FVector origin = collection->GetPointRange(first, last).GetCenter();
+		FVector size(m_heatmapSize, m_heatmapSize, m_heatmapSize);
 
-		range.Max.X += m_heatmapSize;
-		range.Max.Y += m_heatmapSize;
-		range.Max.Z += m_heatmapSize;
+		//For each segment, collect all of the points inside and decide what data to watch based on the heatmap type
+		float scaledHeatmapSize = m_heatmapSize / 100;
+		ATelemetryEvent* tempActor;
+		FString tempName = "Heatmap";
+		FVector tempPoint;
+		TMap<FVector, HeatmapNode> heatmapNodes;
 
-		for (int x = range.Min.X + extent; x < range.Max.X; x += m_heatmapSize)
+		FActorSpawnParameters params;
+		params.Name = *tempName;
+
+		if (m_heatmapMinValue == -1 && m_heatmapMaxValue == -1)
 		{
-			for (int y = range.Min.Y + extent; y < range.Max.Y; y += m_heatmapSize)
+			int largestValue = 0;
+			int largestNumValue = 0;
+
+			if (m_heatmapOrientation)
 			{
-				for (int z = range.Min.Z + extent; z < range.Max.Z; z += m_heatmapSize)
+				for (int j = first; j <= last; j++)
 				{
-					parts.Add(FBox::BuildAABB(FVector(x, y, z), extents));
+					tempPoint = (collection->events[j]->point - origin) / size;
+					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+
+					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+
+					tempEvent.numValues++;
+					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+					tempEvent.orientation += collection->events[j]->orientation;
+
+					largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
+					largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
+				}
+
+				for (auto& node : heatmapNodes)
+				{
+					node.Value.orientation = node.Value.orientation / node.Value.numValues;
+				}
+			}
+			else
+			{
+				for (int j = first; j <= last; j++)
+				{
+					tempPoint = (collection->events[j]->point - origin) / size;
+					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+
+					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+
+					tempEvent.numValues++;
+					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+
+					largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
+					largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
+				}
+			}
+
+			m_heatmapMinValue = 0;
+
+			if (m_heatmapType == HeatmapType::Value || m_heatmapType == HeatmapType::Value_Bar)
+			{
+				if (m_subVizSelection->StartsWith("pct_"))
+				{
+					m_heatmapMaxValue = 100;
+				}
+				else
+				{
+					m_heatmapMaxValue = largestValue;
+				}
+			}
+			else
+			{
+				m_heatmapMaxValue = largestNumValue;
+			}
+
+			m_heatmapMinValueText->SetText(FText::FromString("0"));
+			m_heatmapMaxValueText->SetText(FText::FromString(FString::FromInt(m_heatmapMaxValue)));
+		}
+		else
+		{
+			if (m_heatmapOrientation)
+			{
+				for (int j = first; j <= last; j++)
+				{
+					tempPoint = (collection->events[j]->point - origin) / size;
+					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+
+					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+
+					tempEvent.numValues++;
+					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+					tempEvent.orientation += collection->events[j]->orientation;
+				}
+
+				for (auto& node : heatmapNodes)
+				{
+					node.Value.orientation = node.Value.orientation / node.Value.numValues;
+				}
+			}
+			else
+			{
+				for (int j = first; j <= last; j++)
+				{
+					tempPoint = (collection->events[j]->point - origin) / size;
+					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+
+					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+
+					tempEvent.numValues++;
+					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
 				}
 			}
 		}
 
-		if (parts.Num() > 0)
+		if(heatmapNodes.Num() > 0)
 		{
-			//For each segment, collect all of the points inside and decide what data to watch based on the heatmap type
-			TArray<int> numValues;
-			TArray<int> values;
-			TArray<FVector> orientation;
-			float scaledHeatmapSize = m_heatmapSize / 100;
-			ATelemetryEvent* tempActor;
-			FString tempName = "Heatmap";
-
-			FActorSpawnParameters params;
-			params.Name = *tempName;
-
-			numValues.SetNumZeroed(parts.Num());
-			values.SetNumZeroed(parts.Num());
-			orientation.SetNumZeroed(parts.Num());
-
-			if (m_heatmapMinValue == -1 && m_heatmapMaxValue == -1)
-			{
-				int largestValue = 0;
-				int largestNumValue = 0;
-
-				if (m_heatmapOrientation)
-				{
-					for (int i = 0; i < parts.Num(); i++)
-					{
-						for (int j = first; j <= last; j++)
-						{
-							if (parts[i].IsInside(collection->events[j]->point))
-							{
-								numValues[i]++;
-								orientation[i] += collection->events[j]->orientation;
-								values[i] += collection->events[j]->value;
-							}
-						}
-
-						largestValue = FMath::Max(largestValue, values[i]);
-						largestNumValue = FMath::Max(largestNumValue, numValues[i]);
-						orientation[i] = orientation[i] / numValues[i];
-					}
-				}
-				else
-				{
-					for (int i = 0; i < parts.Num(); i++)
-					{
-						for (int j = first; j <= last; j++)
-						{
-							if (parts[i].IsInside(collection->events[j]->point))
-							{
-								numValues[i]++;
-								values[i] += collection->events[j]->value;
-							}
-						}
-
-						largestValue = FMath::Max(largestValue, values[i]);
-						largestNumValue = FMath::Max(largestNumValue, numValues[i]);
-					}
-				}
-
-				m_heatmapMinValue = 0;
-
-				if (m_heatmapType == HeatmapType::Value || m_heatmapType == HeatmapType::Value_Bar)
-				{
-					if (collection->IsPercentage())
-					{
-						m_heatmapMaxValue = 100;
-					}
-					else
-					{
-						m_heatmapMaxValue = largestValue;
-					}
-				}
-				else
-				{
-					m_heatmapMaxValue = largestNumValue;
-				}
-
-				m_heatmapMinValueText->SetText(FText::FromString("0"));
-				m_heatmapMaxValueText->SetText(FText::FromString(FString::FromInt(m_heatmapMaxValue)));
-			}
-			else
-			{
-				if (m_heatmapOrientation)
-				{
-					for (int i = 0; i < parts.Num(); i++)
-					{
-						for (int j = first; j <= last; j++)
-						{
-							if (parts[i].IsInside(collection->events[j]->point))
-							{
-								numValues[i]++;
-								orientation[i] += collection->events[j]->orientation;
-								values[i] += collection->events[j]->value;
-							}
-						}
-
-						orientation[i] = orientation[i] / numValues[i];
-					}
-				}
-				else
-				{
-					for (int i = 0; i < parts.Num(); i++)
-					{
-						for (int j = first; j <= last; j++)
-						{
-							if (parts[i].IsInside(collection->events[j]->point))
-							{
-								numValues[i]++;
-								values[i] += collection->events[j]->value;
-							}
-						}
-					}
-				}
-			}
-
 			//For each section, add instanced mesh to the master mesh and set its shape and color as needed
 			tempActor = currentTarget->SpawnActor<ATelemetryEvent>(FVector::ZeroVector, FRotator::ZeroRotator, params);
 			tempActor->SetActorLabel(*tempName);
@@ -1087,70 +1128,54 @@ FReply FTelemetryVisualizerUI::GenerateHeatmap(SEventEditorContainer* collection
 
 			if (m_heatmapType == HeatmapType::Value)
 			{
-				for (int i = 0; i < parts.Num(); i++)
+				for (auto& node : heatmapNodes)
 				{
-					if (values[i] > 0)
-					{
-						tempValue = ((float)values[i] / numValues[i]) / m_heatmapMaxValue;
-						tempColorValue = (((float)values[i] / numValues[i]) - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-						tempColorValue = FMath::Max(tempColorValue, 0.f);
-						tempColorValue = FMath::Min(tempColorValue, (float)m_heatmapMaxValue);
+					tempValue = (float)node.Value.values / node.Value.numValues;
+					tempColorValue = (((float)node.Value.values / node.Value.numValues) - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
 
-						tempActor->AddEvent(parts[i].GetCenter(), orientation[i], m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
-					}
+					tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
 				}
 			}
 			else if (m_heatmapType == HeatmapType::Population)
 			{
-				for (int i = 0; i < parts.Num(); i++)
+				for (auto& node : heatmapNodes)
 				{
-					if (numValues[i] > 0)
-					{
-						tempValue = (float)numValues[i] / m_heatmapMaxValue;
-						tempColorValue = (float)(numValues[i] - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-						tempColorValue = FMath::Max(tempColorValue, 0.f);
-						tempColorValue = FMath::Min(tempColorValue, (float)m_heatmapMaxValue);
+					tempValue = (float)node.Value.numValues / m_heatmapMaxValue;
+					tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
 
-						tempActor->AddEvent(parts[i].GetCenter(), orientation[i], m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
-					}
+					tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
 				}
 			}
 			else if (m_heatmapType == HeatmapType::Value_Bar)
 			{
 				float tempHeight;
 
-				for (int i = 0; i < parts.Num(); i++)
+				for (auto& node : heatmapNodes)
 				{
-					if (values[i] > 0)
-					{
-						tempValue = ((float)values[i] / numValues[i]) / m_heatmapMaxValue;
-						tempColorValue = (((float)values[i] / numValues[i]) - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-						tempColorValue = FMath::Max(tempColorValue, 0.f);
-						tempColorValue = FMath::Min(tempColorValue, (float)m_heatmapMaxValue);
-						tempHeight = (((float)values[i] / numValues[i]) / m_heatmapMaxValue) * scaledHeatmapSize;
+					tempValue = (float)node.Value.values / node.Value.numValues;
+					tempColorValue = (((float)node.Value.values / node.Value.numValues) - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+					tempHeight = (((float)node.Value.values / node.Value.numValues) / m_heatmapMaxValue) * scaledHeatmapSize;
 
-						tempActor->AddEvent(parts[i].GetCenter(), FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
-							FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
-					}
+					tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
+						FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
 				}
 			}
 			else if (m_heatmapType == HeatmapType::Population_Bar)
 			{
 				float tempHeight;
 
-				for (int i = 0; i < parts.Num(); i++)
+				for (auto& node : heatmapNodes)
 				{
-					if (numValues[i] > 0)
-					{
-						tempValue = (float)numValues[i] / m_heatmapMaxValue;
-						tempColorValue = (float)(numValues[i] - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-						tempColorValue = FMath::Max(tempColorValue, 0.f);
-						tempColorValue = FMath::Min(tempColorValue, (float)m_heatmapMaxValue);
-						tempHeight = ((float)numValues[i] / m_heatmapMaxValue) * scaledHeatmapSize;
+					tempValue = (float)node.Value.numValues / m_heatmapMaxValue;
+					tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+					tempHeight = ((float)node.Value.numValues / m_heatmapMaxValue) * scaledHeatmapSize;
 
-						tempActor->AddEvent(parts[i].GetCenter(), FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
-							FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
-					}
+					tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
+						FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
 				}
 			}
 
@@ -1163,134 +1188,3 @@ FReply FTelemetryVisualizerUI::GenerateHeatmap(SEventEditorContainer* collection
 
 	return FReply::Handled();
 }
-
-//void FTelemetryVisualizerUI::CreateHeatmapActor(UWorld* drawTarget, int index, FVector location, int value, int range, EventType shape, float size)
-//{
-//	ATelemetryEvent* tempActor;
-//	FString tempName;
-//		
-//	tempName = "Heatmap " + FString::FromInt(index);
-//
-//	FActorSpawnParameters params;
-//	params.Name = *tempName;
-//
-//	tempActor = drawTarget->SpawnActor<ATelemetryEvent>(FVector::ZeroVector, FRotator::ZeroRotator, params);
-//	tempActor->SetActorLabel(*tempName);
-//	tempActor->AddEvent(location, m_heatmapColor.GetColorFromRange((float)value / range), shape, size / 100);
-//
-//	tempActor->SetValue(value);
-//	tempActor->SetRange(range);
-//
-//	tempName = "/TelemetryEvents/Heatmap";
-//	tempActor->SetFolderPath(*tempName);
-//
-//	m_eventActors.Add(tempActor);
-//}
-//
-//void FTelemetryVisualizerUI::CombineHeatmap()
-//{
-//	TArray<AStaticMeshActor*> AllActors;
-//	TArray<UPrimitiveComponent*> AllComponents;
-//	FString BasePackageName;
-//	FMeshMergingSettings MeshMergingSettings;
-//
-//	if (m_eventActors.Num() == 0) return;
-//
-//	AllActors.SetNum(m_eventActors.Num());
-//	AllComponents.SetNum(m_eventActors.Num());
-//
-//	for (int i = 0; i < m_eventActors.Num(); i++)
-//	{
-//		AllActors[i] = (AStaticMeshActor*)m_eventActors[i];
-//
-//		TInlineComponentArray<UStaticMeshComponent*> ComponentArray;
-//		AllActors[i]->GetComponents<UStaticMeshComponent>(ComponentArray);
-//
-//		for (UStaticMeshComponent* MeshCmp : ComponentArray)
-//		{
-//			if (MeshCmp->GetStaticMesh() && MeshCmp->GetStaticMesh()->RenderData.IsValid())
-//			{
-//				AllComponents[i] = MeshCmp;
-//				break;
-//			}
-//		}
-//	}
-//
-//	TArray<UObject*> CreatedAssets;
-//	FVector MergedActorLocation;
-//	const float ScreenAreaSize = TNumericLimits<float>::Max();
-//	const IMeshMergeUtilities& MeshUtilities = FModuleManager::Get().LoadModuleChecked<IMeshMergeModule>("MeshMergeUtilities").GetUtilities();
-//	MeshUtilities.MergeComponentsToStaticMesh(
-//		AllComponents,
-//		AllActors[0]->GetWorld(),
-//		MeshMergingSettings,
-//		nullptr,
-//		nullptr,
-//		BasePackageName,
-//		CreatedAssets,
-//		MergedActorLocation,
-//		ScreenAreaSize,
-//		true);
-//
-//	UWorld* currentTarget = GetLocalWorld();
-//
-//	if (currentTarget != nullptr)
-//	{
-//		DestroyActors();
-//		AStaticMeshActor* tempActor;
-//		FString tempName;
-//		FActorSpawnParameters params;
-//		UStaticMesh* mesh;
-//		UMaterialInterface * Material;
-//		UMaterialInstanceDynamic* matInstance;
-//
-//		if (m_material == nullptr)
-//		{
-//			for (TObjectIterator<UMaterial> It; It; ++It)
-//			{
-//				if ((*It)->GetName() == "M_Telemetry")
-//				{
-//					m_material = *It;
-//					break;
-//				}
-//			}
-//		}
-//
-//		for (int i = 0; i < CreatedAssets.Num(); i++)
-//		{
-//			if (CreatedAssets[i]->IsA(UStaticMesh::StaticClass()))
-//			{
-//				mesh = (UStaticMesh*)CreatedAssets[i];
-//				tempName = "Heatmap " + FString::FromInt(i);
-//				params.Name = *tempName;
-//
-//				tempActor = currentTarget->SpawnActor<AStaticMeshActor>(MergedActorLocation, FRotator::ZeroRotator, params);
-//				tempActor->SetActorLabel(*tempName);
-//				tempActor->GetStaticMeshComponent()->SetRelativeLocation(FVector(0.0f, 0.0f, 0.0f));
-//				tempActor->GetStaticMeshComponent()->SetStaticMesh(mesh);
-//
-//				for (int j = 0; j < tempActor->GetStaticMeshComponent()->GetNumMaterials(); j++)
-//				{
-//					if (m_material != nullptr)
-//					{
-//						tempActor->GetStaticMeshComponent()->SetMaterial(j, m_material);
-//
-//						Material = tempActor->GetStaticMeshComponent()->GetMaterial(j);
-//						matInstance = tempActor->GetStaticMeshComponent()->CreateDynamicMaterialInstance(j, Material);
-//
-//						if (matInstance != nullptr)
-//						{
-//							matInstance->SetVectorParameterValue("Color", FLinearColor(FColor::Green));
-//							tempActor->GetStaticMeshComponent()->SetMaterial(j, matInstance);
-//						}
-//					}
-//				}
-//
-//				tempName = "/TelemetryEvents/Heatmap";
-//				tempActor->SetFolderPath(*tempName);
-//
-//				m_eventActors.Add(tempActor);
-//			}
-//		}
-//	}
-//}

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
@@ -34,6 +34,8 @@ void FTelemetryVisualizerUI::Initialize()
 	m_anim_scrollBarLocation = 0.f;
 	m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
 	m_vizSelection = m_eventgroupList[0];
+	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+	m_subVizSelection = m_eventgroupSubList[0];
 
 	//Default heatmap state
 	m_heatmapType = HeatmapType::Population;

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
@@ -62,6 +62,7 @@ public:
 
 	TSharedRef<SWidget> MakeWidgetForOption(TSharedPtr<FString> InOption);
 	void GenerateEventBox();
+	void GenerateSubEventBox(int index);
 
 	//Event Collection
 	void QueryResults(TSharedPtr<SQueryResult> results);
@@ -72,7 +73,9 @@ public:
 
 	//Viz tab event selection
 	void OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+	void OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
 	FText GetCurrentVizItem() const;
+	FText GetCurrentSubVizItem() const;
 
 	//Query Scroll box
 	void GenerateQueryScrollBox();
@@ -182,14 +185,17 @@ public:
 	TSharedPtr<SScrollBox> m_scrollBox;
 	TSharedPtr<SScrollBox> m_queryScrollBox;
 	TArray<TSharedPtr<FString>> m_eventgroupList;
+	TArray<TSharedPtr<FString>> m_eventgroupSubList;
 	TArray<TSharedPtr<FString>> m_shapeList;
 	TArray<TSharedPtr<FString>> m_heatmapTypeList;
 	TArray<TSharedPtr<FString>> m_queryFieldList;
 	TArray<TSharedPtr<FString>> m_queryOperatorList;
 	TArray<TSharedPtr<FString>> m_queryAndOrList;
 	TSharedPtr<FString> m_vizSelection;
+	TSharedPtr<FString> m_subVizSelection;
 	TSharedPtr<SSlider> m_animationSlider;
 	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizChoice;
+	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizSubChoice;
 	TSharedPtr<SBorder> m_heatmapLowColorButton;
 	TSharedPtr<SBorder> m_heatmapHighColorButton;
 

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
@@ -358,6 +358,17 @@ public:
 		return GetVector(CAM_DIR);
 	}
 
+	void GetAttributes(TMap<FString, TSharedPtr<FJsonValue>>& inMap)
+	{
+		for (auto& attr : Attributes)
+		{
+			if (attr.Key.StartsWith("pct_") || attr.Key.StartsWith("val_"))
+			{
+				inMap.Add(attr.Key, attr.Value);
+			}
+		}
+	}
+
 	bool GetString(const FString &Name, FString &OutString) const
 	{
 		TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);

--- a/docs/UE4_Instructions.md
+++ b/docs/UE4_Instructions.md
@@ -114,14 +114,7 @@ FTelemetry::Position(Pawn->GetActorLocation())
 FTelemetry::Orientation(rotator.Vector())
 ```
 
-2.	If your event has related data that can be used by the heatmap generator (or that you would like attached to each event drawn), a “disp_val” property is needed to direct what event value is needed:
-
-Example:
-```cpp
-FTelemetry::DisplayValue(L”val_health”)
-```
-
-3.	The value that “disp_val” uses will also need to be populated
+2.	Provide data that you would like to view
 
     + For percentages, either prefix your property with “pct_” or use the construction shortcut Percentage.  This will let the visualizer know that the value is a float between 0 and 100.
    
@@ -143,8 +136,7 @@ FTelemetryBuilder Builder;
 Builder.SetProperties({
 	FTelemetry::Position(Pawn->GetActorLocation()),
 	FTelemetry::Orientation(rotator.Vector()),
-	FTelemetry::Value(L"health", MyHealth),
-        FTelemetry::DisplayValue(L”val_health”)
+	FTelemetry::Value(L"health", MyHealth)
 	});
 
 FTelemetry::Record(L”Health”, L”Gameplay”, L”1.3”, MoveTemp(Builder));
@@ -189,13 +181,14 @@ Once you have data uploaded, you are ready to start visualizing it!
 
     ![alt text](\images\heatmap.png)
 
-11. Type represents the type of heatmap you would like to generate.
+11. Value is what values within the events to use to generate the heatmap.
+12. Type represents the type of heatmap you would like to generate.
     + *Population* combines events into physical groups and displays a heatmap of the number of each event within a given group.
     + *Population - Bar* does the same, but generates a 3D bar graph over the XY plane.
     + *Value* also combines events into physical groups, but displays a heatmap of the average of the value of each event within a given group.
     + *Value - Bar* provides a 3D bar graph of value information.
-12. Shape and shape size represent the shape of the heatmap elements along with their radius.  The smaller the radius, the more detailed the information (though also the more complex the heatmap is to generate).
-13. The color range provides the color for the minimum and maximum values in the map.  Colors in between are a fade between the two colors chosen.
-14. Type range will populate when you generate the heatmap, but can be used to adjust the colors.  This can be helpful when your data has outlying values that can cause the heatmap to lack variability.  Adjust the range to remove extreme highs and lows to get more interesting information.
-15. Use Orientation will rotate the heatmap shapes to the average orientation of all events within each element.
-16. Apply to Animation will allow the animation controls above control animating the entire heatmap
+13. Shape and shape size represent the shape of the heatmap elements along with their radius.  The smaller the radius, the more detailed the information (though also the more complex the heatmap is to generate).
+14. The color range provides the color for the minimum and maximum values in the map.  Colors in between are a fade between the two colors chosen.
+15. Type range will populate when you generate the heatmap, but can be used to adjust the colors.  This can be helpful when your data has outlying values that can cause the heatmap to lack variability.  Adjust the range to remove extreme highs and lows to get more interesting information.
+16. Use Orientation will rotate the heatmap shapes to the average orientation of all events within each element.
+17. Apply to Animation will allow the animation controls above control animating the entire heatmap


### PR DESCRIPTION
Removing the use of "disp_val" and supporting all values attached to an event.  This change requires the following:
- Removing event parsing/construction for disp_val
- Removing percentage check out of the events
- Swapping the actor value to a map of strings for detail display
- Swapping the events to a map of JSON values
- Caching attribute names for each event container
- Adding UI elements to select the value for heatmap generation
- Optimizing the heatmap generation (needed to be done anyway) to offset any additional cost of parsing attribute maps for values rather than using static ones
