### PR TITLE
Lifespan update heatmap

### DIFF
--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/Telemetry.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/Telemetry.cpp
@@ -20,17 +20,17 @@ DEFINE_LOG_CATEGORY(LogTelemetry);
 
 FString FTelemetry::DumpJson(FTelemetryProperties Properties)
 {
-	FString Result;
+    FString Result;
 
-	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Result);
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Result);
 
-	Writer->WriteObjectStart();
-	FTelemetryJsonSerializer::Serialize(Properties, Writer);
-	Writer->WriteObjectEnd();
+    Writer->WriteObjectStart();
+    FTelemetryJsonSerializer::Serialize(Properties, Writer);
+    Writer->WriteObjectEnd();
 
-	Writer->Close();
+    Writer->Close();
 
-	return Result;
+    return Result;
 }
 
 

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryJson.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryJson.cpp
@@ -15,117 +15,117 @@
 
 void FTelemetryJsonSerializer::Serialize(const FTelemetryProperties &Container, const TSharedRef<TJsonWriter<>> &Writer)
 {
-	for (const FTelemetryProperty &Property : Container)
-	{
-		Serialize(Property, Writer);
-	}
+    for (const FTelemetryProperty &Property : Container)
+    {
+        Serialize(Property, Writer);
+    }
 }
 
 void FTelemetryJsonSerializer::Serialize(const FTelemetryProperty &Property, const TSharedRef<TJsonWriter<>> &Writer)
 {
-	switch (Property.Value.GetType())
-	{
-		case EVariantTypes::Empty:
-			Writer->WriteValue(Property.Key, TEXT(""));
-			break; // todo(scmatlof): error type
-		
-		// Dates
-		case EVariantTypes::DateTime:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<FDateTime>().ToIso8601());
-			break;
-		
-		// Misc
-		case EVariantTypes::Guid:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<FGuid>().ToString());
-			break;
-		case EVariantTypes::ByteArray: // todo(scmatlof): Support base64?
-			Writer->WriteValue(Property.Key, FBase64::Encode(Property.Value.GetBytes()));
-			break;
+    switch (Property.Value.GetType())
+    {
+        case EVariantTypes::Empty:
+            Writer->WriteValue(Property.Key, TEXT(""));
+            break; // todo(scmatlof): error type
+        
+        // Dates
+        case EVariantTypes::DateTime:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<FDateTime>().ToIso8601());
+            break;
+        
+        // Misc
+        case EVariantTypes::Guid:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<FGuid>().ToString());
+            break;
+        case EVariantTypes::ByteArray: // todo(scmatlof): Support base64?
+            Writer->WriteValue(Property.Key, FBase64::Encode(Property.Value.GetBytes()));
+            break;
 
-		// Numerics
-		case EVariantTypes::Bool:
-			Writer->WriteValue<uint8>(Property.Key, Property.Value.GetValue<bool>() ? 1 : 0);
-			break;
-		case EVariantTypes::UInt8:
-			Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint8>());
-			break;
-		case EVariantTypes::UInt16:
-			Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint16>());
-			break;
-		case EVariantTypes::UInt32:
-			Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint32>());
-			break;
-		case EVariantTypes::UInt64:
-			Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint64>());
-			break;
-		case EVariantTypes::Int8:
-			Writer->WriteValue<int8>(Property.Key, Property.Value.GetValue<int8>());
-			break;
-		case EVariantTypes::Int16:
-			Writer->WriteValue<int16>(Property.Key, Property.Value.GetValue<int16>());
-			break;
-		case EVariantTypes::Int32:
-			Writer->WriteValue<int32>(Property.Key, Property.Value.GetValue<int32>());
-			break;
-		case EVariantTypes::Int64:
-			Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<int64>());
-			break;
-		case EVariantTypes::Float:
-			Writer->WriteValue<float>(Property.Key, Property.Value.GetValue<float>());
-			break;
-		case EVariantTypes::Double:
-			Writer->WriteValue<double>(Property.Key, Property.Value.GetValue<double>());
-			break;
+        // Numerics
+        case EVariantTypes::Bool:
+            Writer->WriteValue<uint8>(Property.Key, Property.Value.GetValue<bool>() ? 1 : 0);
+            break;
+        case EVariantTypes::UInt8:
+            Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint8>());
+            break;
+        case EVariantTypes::UInt16:
+            Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint16>());
+            break;
+        case EVariantTypes::UInt32:
+            Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint32>());
+            break;
+        case EVariantTypes::UInt64:
+            Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<uint64>());
+            break;
+        case EVariantTypes::Int8:
+            Writer->WriteValue<int8>(Property.Key, Property.Value.GetValue<int8>());
+            break;
+        case EVariantTypes::Int16:
+            Writer->WriteValue<int16>(Property.Key, Property.Value.GetValue<int16>());
+            break;
+        case EVariantTypes::Int32:
+            Writer->WriteValue<int32>(Property.Key, Property.Value.GetValue<int32>());
+            break;
+        case EVariantTypes::Int64:
+            Writer->WriteValue<int64>(Property.Key, Property.Value.GetValue<int64>());
+            break;
+        case EVariantTypes::Float:
+            Writer->WriteValue<float>(Property.Key, Property.Value.GetValue<float>());
+            break;
+        case EVariantTypes::Double:
+            Writer->WriteValue<double>(Property.Key, Property.Value.GetValue<double>());
+            break;
 
-		// Strings
-		/*case EVariantTypes::Ansichar:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<ANSICHAR>());
-			break;
-		case EVariantTypes::Widechar:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<WIDECHAR>());
-			break;*/
-		case EVariantTypes::String:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<FString>());
-			break;
-		/*case EVariantTypes::Property.Key:
-			Writer->WriteValue(Property.Key, Property.Value.GetValue<FProperty.Key>().);
-			break;*/
-		
-		// Vectors
-		case EVariantTypes::Vector:
-		{
-			FVector V(Property.Value.GetValue<FVector>());
-			Writer->WriteValue(Property.Key + "_x", V.X);
-			Writer->WriteValue(Property.Key + "_y", V.Y);
-			Writer->WriteValue(Property.Key + "_z", V.Z);
-		}
-		break;
-		case EVariantTypes::Vector2d:
-		{
-			FVector2D V(Property.Value.GetValue<FVector2D>());
-			Writer->WriteValue(Property.Key + "_x", V.X);
-			Writer->WriteValue(Property.Key + "_y", V.Y);
-		}
-		break;
-		case EVariantTypes::Vector4:
-		{
-			FVector4 V(Property.Value.GetValue<FVector4>());
-			Writer->WriteValue(Property.Key + "_x", V.X);
-			Writer->WriteValue(Property.Key + "_y", V.Y);
-			Writer->WriteValue(Property.Key + "_z", V.Z);
-			Writer->WriteValue(Property.Key + "_w", V.W);
-		}
-		break;
-		case EVariantTypes::IntVector:
-		{
-			FIntVector V(Property.Value.GetValue<FIntVector>());
-			Writer->WriteValue(Property.Key + "_x", V.X);
-			Writer->WriteValue(Property.Key + "_y", V.Y);
-			Writer->WriteValue(Property.Key + "_z", V.Z);
-		}
-		break;
+        // Strings
+        /*case EVariantTypes::Ansichar:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<ANSICHAR>());
+            break;
+        case EVariantTypes::Widechar:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<WIDECHAR>());
+            break;*/
+        case EVariantTypes::String:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<FString>());
+            break;
+        /*case EVariantTypes::Property.Key:
+            Writer->WriteValue(Property.Key, Property.Value.GetValue<FProperty.Key>().);
+            break;*/
+        
+        // Vectors
+        case EVariantTypes::Vector:
+        {
+            FVector V(Property.Value.GetValue<FVector>());
+            Writer->WriteValue(Property.Key + "_x", V.X);
+            Writer->WriteValue(Property.Key + "_y", V.Y);
+            Writer->WriteValue(Property.Key + "_z", V.Z);
+        }
+        break;
+        case EVariantTypes::Vector2d:
+        {
+            FVector2D V(Property.Value.GetValue<FVector2D>());
+            Writer->WriteValue(Property.Key + "_x", V.X);
+            Writer->WriteValue(Property.Key + "_y", V.Y);
+        }
+        break;
+        case EVariantTypes::Vector4:
+        {
+            FVector4 V(Property.Value.GetValue<FVector4>());
+            Writer->WriteValue(Property.Key + "_x", V.X);
+            Writer->WriteValue(Property.Key + "_y", V.Y);
+            Writer->WriteValue(Property.Key + "_z", V.Z);
+            Writer->WriteValue(Property.Key + "_w", V.W);
+        }
+        break;
+        case EVariantTypes::IntVector:
+        {
+            FIntVector V(Property.Value.GetValue<FIntVector>());
+            Writer->WriteValue(Property.Key + "_x", V.X);
+            Writer->WriteValue(Property.Key + "_y", V.Y);
+            Writer->WriteValue(Property.Key + "_z", V.Z);
+        }
+        break;
 
-		default:
-			break;
-	}
+        default:
+            break;
+    }
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryJson.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryJson.h
@@ -14,6 +14,6 @@
 class GAMETELEMETRY_API FTelemetryJsonSerializer
 {
 public:
-	static void Serialize(const FTelemetryProperties &Container, const TSharedRef<TJsonWriter<>> &Writer);
-	static void Serialize(const FTelemetryProperty &Property, const TSharedRef<TJsonWriter<>> &Writer);
+    static void Serialize(const FTelemetryProperties &Container, const TSharedRef<TJsonWriter<>> &Writer);
+    static void Serialize(const FTelemetryProperty &Property, const TSharedRef<TJsonWriter<>> &Writer);
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryManager.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryManager.cpp
@@ -27,213 +27,213 @@ TAtomic<uint32> Sequence;
 class FTelemetryBatchPayload
 {
 public:
-	FTelemetryBatchPayload(const FTelemetryProperties &Common) :
-		Payload(),
-		IsFinalized(false),
-		Writer(TJsonWriterFactory<>::Create(&Payload))
-	{
-		Writer->WriteObjectStart(); // Outer most object
-		Writer->WriteObjectStart("header"); // header portion
-		FTelemetryJsonSerializer::Serialize(Common, Writer);
-		Writer->WriteObjectEnd();
-		Writer->WriteArrayStart("events"); // Events array
-	}
+    FTelemetryBatchPayload(const FTelemetryProperties &Common) :
+        Payload(),
+        IsFinalized(false),
+        Writer(TJsonWriterFactory<>::Create(&Payload))
+    {
+        Writer->WriteObjectStart(); // Outer most object
+        Writer->WriteObjectStart("header"); // header portion
+        FTelemetryJsonSerializer::Serialize(Common, Writer);
+        Writer->WriteObjectEnd();
+        Writer->WriteArrayStart("events"); // Events array
+    }
 
-	void AddTelemetry(FTelemetryProperties Event)
-	{
-		check(!IsFinalized);
+    void AddTelemetry(FTelemetryProperties Event)
+    {
+        check(!IsFinalized);
 
-		Writer->WriteObjectStart();
-		FTelemetryJsonSerializer::Serialize(Event, Writer);
-		Writer->WriteObjectEnd();
-	}
+        Writer->WriteObjectStart();
+        FTelemetryJsonSerializer::Serialize(Event, Writer);
+        Writer->WriteObjectEnd();
+    }
 
-	const FString & Finalize()
-	{
-		check(!IsFinalized); // Shouldn't call finalize more than once
+    const FString & Finalize()
+    {
+        check(!IsFinalized); // Shouldn't call finalize more than once
 
-		if (!IsFinalized) // Nothing really bad happens though...
-		{
-			Writer->WriteArrayEnd();
-			Writer->WriteObjectEnd();
-			Writer->Close();
-			IsFinalized = true;
-		}
+        if (!IsFinalized) // Nothing really bad happens though...
+        {
+            Writer->WriteArrayEnd();
+            Writer->WriteObjectEnd();
+            Writer->Close();
+            IsFinalized = true;
+        }
 
-		check(Payload.IsEmpty() == false);
-		return Payload;
-	}
+        check(Payload.IsEmpty() == false);
+        return Payload;
+    }
 
-	const FString &GetPayload() { return Payload; }
+    const FString &GetPayload() { return Payload; }
 
 private:
-	FString Payload;
-	TSharedRef<TJsonWriter<>> Writer;
-	bool IsFinalized;
+    FString Payload;
+    TSharedRef<TJsonWriter<>> Writer;
+    bool IsFinalized;
 };
 
 class FTelemetryWorker : public FRunnable
 {
 public:
 
-	FTelemetryWorker(FString IngestUrl, double SendInterval = 10.0, int PendingBufferSize = 127) :
-		IngestUrl(IngestUrl),
-		SendInterval(SendInterval),
-		ShouldRun(true),
-		IsComplete(false),
-		Pending(PendingBufferSize)
-	{
+    FTelemetryWorker(FString IngestUrl, double SendInterval = 10.0, int PendingBufferSize = 127) :
+        IngestUrl(IngestUrl),
+        SendInterval(SendInterval),
+        ShouldRun(true),
+        IsComplete(false),
+        Pending(PendingBufferSize)
+    {
 
-		Thread = TUniquePtr<FRunnableThread>(FRunnableThread::Create(this, TEXT("TelemetryUploadThread"), 0, EThreadPriority::TPri_BelowNormal));
-	}
+        Thread = TUniquePtr<FRunnableThread>(FRunnableThread::Create(this, TEXT("TelemetryUploadThread"), 0, EThreadPriority::TPri_BelowNormal));
+    }
 
-	virtual ~FTelemetryWorker()
-	{
-		Sync.Release();
-		Thread.Release();
-	}
+    virtual ~FTelemetryWorker()
+    {
+        Sync.Release();
+        Thread.Release();
+    }
 
-	virtual bool Init() override
-	{
-		Sync = TUniquePtr<FEvent>(FGenericPlatformProcess::GetSynchEventFromPool());
-		return true;
-	}
+    virtual bool Init() override
+    {
+        Sync = TUniquePtr<FEvent>(FGenericPlatformProcess::GetSynchEventFromPool());
+        return true;
+    }
 
-	virtual uint32 Run() override
-	{
-		while (ShouldRun)
-		{
-			Sync->Wait(FTimespan::FromSeconds(SendInterval));
+    virtual uint32 Run() override
+    {
+        while (ShouldRun)
+        {
+            Sync->Wait(FTimespan::FromSeconds(SendInterval));
 
-			// Flush here
+            // Flush here
 
-			if (Pending.Count() > 0)
-			{
-				SendTelemetry(FTelemetryManager::Get().GetCommonProperties());
-			}
-		}
+            if (Pending.Count() > 0)
+            {
+                SendTelemetry(FTelemetryManager::Get().GetCommonProperties());
+            }
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	virtual void Stop() override
-	{
-		ShouldRun = false;
+    virtual void Stop() override
+    {
+        ShouldRun = false;
 
-		TriggerFlush();
+        TriggerFlush();
 
-		IsComplete = true;
-	}
+        IsComplete = true;
+    }
 
-	virtual void Exit() override
-	{
-		if (!IsComplete)
-		{
-			Stop();
-			Thread->WaitForCompletion();
-		}
-	}
+    virtual void Exit() override
+    {
+        if (!IsComplete)
+        {
+            Stop();
+            Thread->WaitForCompletion();
+        }
+    }
 
-	void TriggerFlush()
-	{
-		if (Sync)
-		{
-			Sync->Trigger();
-		}
-	}
+    void TriggerFlush()
+    {
+        if (Sync)
+        {
+            Sync->Trigger();
+        }
+    }
 
-	void Enqueue(TSharedPtr<FTelemetryBuilder> Properties)
-	{
-		// Circular Queue/Buffer want SPSC model, so limit to the most likely thread telemetry will be generated on
-		if (!IsInGameThread())
-		{
-			AsyncTask(ENamedThreads::GameThread, [this, Properties]() {
-				Pending.Enqueue(Properties);
-			});
-		}
-		else
-		{
-			Pending.Enqueue(Properties);
-		}
-	}
+    void Enqueue(TSharedPtr<FTelemetryBuilder> Properties)
+    {
+        // Circular Queue/Buffer want SPSC model, so limit to the most likely thread telemetry will be generated on
+        if (!IsInGameThread())
+        {
+            AsyncTask(ENamedThreads::GameThread, [this, Properties]() {
+                Pending.Enqueue(Properties);
+            });
+        }
+        else
+        {
+            Pending.Enqueue(Properties);
+        }
+    }
 
-	bool CompressPayload(const FString &Payload, TArray<uint8> &Compressed)
-	{
-		FTCHARToUTF8 PayloadUTF8(*Payload);
+    bool CompressPayload(const FString &Payload, TArray<uint8> &Compressed)
+    {
+        FTCHARToUTF8 PayloadUTF8(*Payload);
 
-		const void *UncompressedPtr = PayloadUTF8.Get();
-		const int32 UncompressedSize = PayloadUTF8.Length() + 1;
-		int32 CompressedSize = 0;
+        const void *UncompressedPtr = PayloadUTF8.Get();
+        const int32 UncompressedSize = PayloadUTF8.Length() + 1;
+        int32 CompressedSize = 0;
 
-		Compressed.AddUninitialized(UncompressedSize * 4 / 3);
-		bool CompressSuccessful = FCompression::CompressMemory((ECompressionFlags)(COMPRESS_GZIP | COMPRESS_BiasMemory), Compressed.GetData(), CompressedSize, UncompressedPtr, UncompressedSize);
-		if (CompressSuccessful)
-		{
-			Compressed.SetNum(CompressedSize, false);
-		}
+        Compressed.AddUninitialized(UncompressedSize * 4 / 3);
+        bool CompressSuccessful = FCompression::CompressMemory((ECompressionFlags)(COMPRESS_GZIP | COMPRESS_BiasMemory), Compressed.GetData(), CompressedSize, UncompressedPtr, UncompressedSize);
+        if (CompressSuccessful)
+        {
+            Compressed.SetNum(CompressedSize, false);
+        }
 
-		return CompressSuccessful;
-	}
+        return CompressSuccessful;
+    }
 
-	void SendTelemetry(const FTelemetryProperties &CommonProperties)
-	{
-		auto request = FTelemetryService::CreateServiceRequest();
+    void SendTelemetry(const FTelemetryProperties &CommonProperties)
+    {
+        auto request = FTelemetryService::CreateServiceRequest();
 
-		FTelemetryBatchPayload BatchPayload(CommonProperties);
+        FTelemetryBatchPayload BatchPayload(CommonProperties);
 
-		TSharedPtr<FTelemetryBuilder> Event;
-		while (Pending.Dequeue(Event))
-		{
-			BatchPayload.AddTelemetry(Event->GetProperties());
-		}
+        TSharedPtr<FTelemetryBuilder> Event;
+        while (Pending.Dequeue(Event))
+        {
+            BatchPayload.AddTelemetry(Event->GetProperties());
+        }
 
-		request->SetURL(IngestUrl);
-		request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
-		request->SetHeader(TEXT("x-ms-payload-type"), TEXT("batch"));
-		request->SetVerb(TEXT("POST"));
+        request->SetURL(IngestUrl);
+        request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+        request->SetHeader(TEXT("x-ms-payload-type"), TEXT("batch"));
+        request->SetVerb(TEXT("POST"));
 
-		const FString &Payload = BatchPayload.Finalize();
-		TArray<uint8> Compressed;
+        const FString &Payload = BatchPayload.Finalize();
+        TArray<uint8> Compressed;
 
-		if (CompressPayload(Payload, Compressed))
-		{
-			request->SetContent(Compressed);
-			request->SetHeader(TEXT("Content-Encoding"), TEXT("gzip"));
-		}
-		else
-		{
-			request->SetContentAsString(Payload);
-		}
+        if (CompressPayload(Payload, Compressed))
+        {
+            request->SetContent(Compressed);
+            request->SetHeader(TEXT("Content-Encoding"), TEXT("gzip"));
+        }
+        else
+        {
+            request->SetContentAsString(Payload);
+        }
 
-		request->OnProcessRequestComplete().BindLambda([](FHttpRequestPtr req, FHttpResponsePtr resp, bool successful)
-		{
-			UE_LOG(LogTelemetry, Display, TEXT("Http telemetry ingestion attempt %s."), successful ? TEXT("succeeded") : TEXT("failed"));
-			if (resp.IsValid())
-			{
-				UE_LOG(LogTelemetry, Display, TEXT("Http Ingestion Response Status: %d"), resp->GetResponseCode());
-				if (resp->GetResponseCode() >= 400)
-				{
-					UE_LOG(LogTelemetry, Error, TEXT("Telemetry Error Information: %s"), *resp->GetContentAsString());
-				}
-			}
-			else
-			{
-				UE_LOG(LogTelemetry, Display, TEXT("No response from ingestion server."));
-			}
-		});
+        request->OnProcessRequestComplete().BindLambda([](FHttpRequestPtr req, FHttpResponsePtr resp, bool successful)
+        {
+            UE_LOG(LogTelemetry, Display, TEXT("Http telemetry ingestion attempt %s."), successful ? TEXT("succeeded") : TEXT("failed"));
+            if (resp.IsValid())
+            {
+                UE_LOG(LogTelemetry, Display, TEXT("Http Ingestion Response Status: %d"), resp->GetResponseCode());
+                if (resp->GetResponseCode() >= 400)
+                {
+                    UE_LOG(LogTelemetry, Error, TEXT("Telemetry Error Information: %s"), *resp->GetContentAsString());
+                }
+            }
+            else
+            {
+                UE_LOG(LogTelemetry, Display, TEXT("No response from ingestion server."));
+            }
+        });
 
-		request->ProcessRequest();
-	}
+        request->ProcessRequest();
+    }
 
 private:
-	TUniquePtr<FRunnableThread> Thread;
-	TUniquePtr<FEvent> Sync;
-	double SendInterval;
-	bool ShouldRun;
-	bool IsComplete;
-	FString IngestUrl;
+    TUniquePtr<FRunnableThread> Thread;
+    TUniquePtr<FEvent> Sync;
+    double SendInterval;
+    bool ShouldRun;
+    bool IsComplete;
+    FString IngestUrl;
 
-	TCircularQueue<TSharedPtr<FTelemetryBuilder>> Pending;
+    TCircularQueue<TSharedPtr<FTelemetryBuilder>> Pending;
 };
 
 static TUniquePtr<FTelemetryWorker> TelemetryWorker;
@@ -244,12 +244,12 @@ FString FTelemetryConfiguration::IniSectionName = TEXT("GameTelemetry");
 
 FTelemetryConfiguration FTelemetryManager::GetConfigFromIni()
 {
-	FTelemetryConfiguration Config;
-	FTelemetryConfiguration::GetString(TEXT("IngestUrl"), Config.IngestionUrl);
-	FTelemetryConfiguration::GetDouble(TEXT("SendInterval"), Config.SendInterval);
-	FTelemetryConfiguration::GetInt(TEXT("MaxBufferSize"), Config.PendingBufferSize);
+    FTelemetryConfiguration Config;
+    FTelemetryConfiguration::GetString(TEXT("IngestUrl"), Config.IngestionUrl);
+    FTelemetryConfiguration::GetDouble(TEXT("SendInterval"), Config.SendInterval);
+    FTelemetryConfiguration::GetInt(TEXT("MaxBufferSize"), Config.PendingBufferSize);
 
-	return Config;
+    return Config;
 }
 
 // Set a new client id - Usually set to the platform client id
@@ -263,77 +263,77 @@ FTelemetryConfiguration FTelemetryManager::GetConfigFromIni()
 
 void FTelemetryManager::Initialize(const FTelemetryConfiguration & Config)
 {
-	if (hasInit)
-	{
-		Instance->Shutdown();
-	}
+    if (hasInit)
+    {
+        Instance->Shutdown();
+    }
 
-	Instance = MakeUnique<FTelemetryManager>(FTelemetryManager(Config));
+    Instance = MakeUnique<FTelemetryManager>(FTelemetryManager(Config));
 
-	//Build type
-	Instance->CommonProperties.SetProperty(L"build_type", EBuildConfigurations::ToString(FApp::GetBuildConfiguration()));
+    //Build type
+    Instance->CommonProperties.SetProperty(L"build_type", EBuildConfigurations::ToString(FApp::GetBuildConfiguration()));
 
-	//Platform
-	Instance->CommonProperties.SetProperty(L"platform", FString(FPlatformProperties::IniPlatformName()));
+    //Platform
+    Instance->CommonProperties.SetProperty(L"platform", FString(FPlatformProperties::IniPlatformName()));
 
-	//Client ID
-	Instance->CommonProperties.SetProperty(L"client_id", FPlatformMisc::GetLoginId());
+    //Client ID
+    Instance->CommonProperties.SetProperty(L"client_id", FPlatformMisc::GetLoginId());
 
-	//Session ID
-	Instance->CommonProperties.SetProperty(L"session_id", FApp::GetSessionId().ToString(EGuidFormats::DigitsWithHyphens));
+    //Session ID
+    Instance->CommonProperties.SetProperty(L"session_id", FApp::GetSessionId().ToString(EGuidFormats::DigitsWithHyphens));
 
-	//Build ID
-	Instance->CommonProperties.SetProperty(L"build_id", FApp::GetBuildVersion());
+    //Build ID
+    Instance->CommonProperties.SetProperty(L"build_id", FApp::GetBuildVersion());
 
-	//Process ID
-	Instance->CommonProperties.SetProperty(L"process_id", FGenericPlatformProcess::GetCurrentProcessId());
+    //Process ID
+    Instance->CommonProperties.SetProperty(L"process_id", FGenericPlatformProcess::GetCurrentProcessId());
 
-	//User ID
-	Instance->CommonProperties.SetProperty(L"user_id", FApp::GetSessionOwner());
+    //User ID
+    Instance->CommonProperties.SetProperty(L"user_id", FApp::GetSessionOwner());
 
-	TelemetryWorker = MakeUnique<FTelemetryWorker>(Config.IngestionUrl, Config.SendInterval, Config.PendingBufferSize);
-	hasInit = true;
+    TelemetryWorker = MakeUnique<FTelemetryWorker>(Config.IngestionUrl, Config.SendInterval, Config.PendingBufferSize);
+    hasInit = true;
 }
 
 void FTelemetryManager::Record(const FString &Name, const FString &Category, const FString &Version, FTelemetryBuilder &&Properties)
 {
-	if (hasInit)
-	{
-		TSharedPtr<FTelemetryBuilder> Evt(new FTelemetryBuilder(MoveTemp(Properties)));
+    if (hasInit)
+    {
+        TSharedPtr<FTelemetryBuilder> Evt(new FTelemetryBuilder(MoveTemp(Properties)));
 
-		Evt->SetProperty(FTelemetry::ClientTimestamp());
-		Evt->SetProperty(FTelemetry::EventName(Name));
-		Evt->SetProperty(FTelemetry::Category(Category));
-		Evt->SetProperty(FTelemetry::Version(Version));
+        Evt->SetProperty(FTelemetry::ClientTimestamp());
+        Evt->SetProperty(FTelemetry::EventName(Name));
+        Evt->SetProperty(FTelemetry::Category(Category));
+        Evt->SetProperty(FTelemetry::Version(Version));
 
-		uint32 CurrentSequence = Sequence++;
-		Evt->SetProperty(TEXT("seq"), FVariant(CurrentSequence));
+        uint32 CurrentSequence = Sequence++;
+        Evt->SetProperty(TEXT("seq"), FVariant(CurrentSequence));
 
-		TelemetryWorker->Enqueue(Evt);
-	}
-	else
-	{
-		UE_LOG(LogTelemetry, Error, TEXT("Cannot record event because the telemetry subsystem has not been initialized."));
-	}
+        TelemetryWorker->Enqueue(Evt);
+    }
+    else
+    {
+        UE_LOG(LogTelemetry, Error, TEXT("Cannot record event because the telemetry subsystem has not been initialized."));
+    }
 
 }
 
 inline void FTelemetryManager::SetClientId(const FString & InClientId)
 {
-	Instance->CommonProperties.SetProperty(FTelemetry::ClientId(InClientId));
+    Instance->CommonProperties.SetProperty(FTelemetry::ClientId(InClientId));
 }
 
 inline void FTelemetryManager::SetSessionId(const FString & InSessionId)
 {
-	Instance->CommonProperties.SetProperty(FTelemetry::SessionId(InSessionId));
+    Instance->CommonProperties.SetProperty(FTelemetry::SessionId(InSessionId));
 }
 
 
 void FTelemetryManager::Shutdown()
 {
-	if (hasInit)
-	{
-		TelemetryWorker->Exit();
-		TelemetryWorker.Release();
-	}
+    if (hasInit)
+    {
+        TelemetryWorker->Exit();
+        TelemetryWorker.Release();
+    }
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryModule.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryModule.cpp
@@ -22,5 +22,5 @@ void FTelemetryModule::StartupModule()
 
 void FTelemetryModule::ShutdownModule()
 {
-	
+    
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryPCH.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Private/TelemetryPCH.h
@@ -22,6 +22,7 @@
 #include "Misc/Variant.h"
 
 #include "Http.h"
-#include "Json.h"
+#include "Serialization/JsonSerializer.h"
+#include "Misc/ConfigCacheIni.h"
 
 #include "Templates/Atomic.h"

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
@@ -28,119 +28,119 @@ FORCEINLINE FString FormatVersion(int32 Major, int32 Minor, int32 Patch) { retur
 class GAMETELEMETRY_API FTelemetry
 {
 public:
-	/**
-		Creates an empty telemetry builder
-	*/
-	FORCEINLINE static FTelemetryBuilder Create() { return FTelemetryBuilder(); }
+    /**
+        Creates an empty telemetry builder
+    */
+    FORCEINLINE static FTelemetryBuilder Create() { return FTelemetryBuilder(); }
 
-	/**
-		Creates a telemetry builder
-		@param Properties: Initial properties to set in this event
-	*/
-	FORCEINLINE static FTelemetryBuilder Create(FTelemetryPropertiesInitializer InitialProperties = {})
-	{
-		FTelemetryBuilder Evt(InitialProperties);
-		return Evt;
-	}
+    /**
+        Creates a telemetry builder
+        @param Properties: Initial properties to set in this event
+    */
+    FORCEINLINE static FTelemetryBuilder Create(FTelemetryPropertiesInitializer InitialProperties = {})
+    {
+        FTelemetryBuilder Evt(InitialProperties);
+        return Evt;
+    }
 
-	/**
-		Creates a telemetry builder
-		@param Properties: Initial properties to set in this event
-	*/
-	FORCEINLINE static FTelemetryBuilder Create(FTelemetryProperties &&Properties)
-	{
-		FTelemetryBuilder Evt(MoveTemp(Properties));
-		return Evt;
-	}
+    /**
+        Creates a telemetry builder
+        @param Properties: Initial properties to set in this event
+    */
+    FORCEINLINE static FTelemetryBuilder Create(FTelemetryProperties &&Properties)
+    {
+        FTelemetryBuilder Evt(MoveTemp(Properties));
+        return Evt;
+    }
 
-	/**
-		Records an event and places it in the buffer to be sent
-		@param Name: Event name
-		@param Category: Category
-		@param Version: Semantic version of this event
-		@param Properties: Properties to set in this event
-	*/
-	FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, const FTelemetryBuilder &Properties)
-	{
-		FTelemetryManager::Get().Record(Name, Category, Version, FTelemetryBuilder(Properties));
-	}
+    /**
+        Records an event and places it in the buffer to be sent
+        @param Name: Event name
+        @param Category: Category
+        @param Version: Semantic version of this event
+        @param Properties: Properties to set in this event
+    */
+    FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, const FTelemetryBuilder &Properties)
+    {
+        FTelemetryManager::Get().Record(Name, Category, Version, FTelemetryBuilder(Properties));
+    }
 
-	/**
-		Records an event and places it in the buffer to be sent
-		@param Name: Event name
-		@param Category: Category
-		@param Version: Semantic version of this event
-		@param Properties: Properties to set in this event
-	*/
-	FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, const FTelemetryProperties &Properties)
-	{ 
-		FTelemetryManager::Get().Record(Name, Category, Version, FTelemetryBuilder(Properties));
-	}
+    /**
+        Records an event and places it in the buffer to be sent
+        @param Name: Event name
+        @param Category: Category
+        @param Version: Semantic version of this event
+        @param Properties: Properties to set in this event
+    */
+    FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, const FTelemetryProperties &Properties)
+    { 
+        FTelemetryManager::Get().Record(Name, Category, Version, FTelemetryBuilder(Properties));
+    }
 
-	/**
-		Records an event and places it in the buffer to be sent
-		@param Name: Event name
-		@param Category: Category
-		@param Version: Semantic version of this event
-		@param InitialProperties: Initializer list of properties to set in this event
-	*/
-	FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, FTelemetryPropertiesInitializer InitialProperties = {})
-	{
-		FTelemetryManager::Get().Record(Name, Category, Version, Create(InitialProperties));
-	}
+    /**
+        Records an event and places it in the buffer to be sent
+        @param Name: Event name
+        @param Category: Category
+        @param Version: Semantic version of this event
+        @param InitialProperties: Initializer list of properties to set in this event
+    */
+    FORCEINLINE static void Record(const FString &Name, const FString &Category, const FString &Version, FTelemetryPropertiesInitializer InitialProperties = {})
+    {
+        FTelemetryManager::Get().Record(Name, Category, Version, Create(InitialProperties));
+    }
 
 // Helper functions for consistently formatting special properties
 public:
-	// Name of the event
-	FORCEINLINE static FTelemetryProperty EventName(const FString &Name) { return FTelemetryProperty(TEXT("name"), Name); }
+    // Name of the event
+    FORCEINLINE static FTelemetryProperty EventName(const FString &Name) { return FTelemetryProperty(TEXT("name"), Name); }
 
-	// Category for an event - Useful for grouping events of a similary type
-	FORCEINLINE static FTelemetryProperty Category(const FString &Value) { return FTelemetryProperty(TEXT("cat"), Value); }
+    // Category for an event - Useful for grouping events of a similary type
+    FORCEINLINE static FTelemetryProperty Category(const FString &Value) { return FTelemetryProperty(TEXT("cat"), Value); }
 
-	// Position vector for an entity
-	FORCEINLINE static FTelemetryProperty Position(const FVector &Value) { return FTelemetryProperty(TEXT("pos"), Value); }
+    // Position vector for an entity
+    FORCEINLINE static FTelemetryProperty Position(const FVector &Value) { return FTelemetryProperty(TEXT("pos"), Value); }
 
-	// Orientation unit vector for an entity
-	FORCEINLINE static FTelemetryProperty Orientation(const FVector &Vec) { return FTelemetryProperty(TEXT("dir"), Vec); }
+    // Orientation unit vector for an entity
+    FORCEINLINE static FTelemetryProperty Orientation(const FVector &Vec) { return FTelemetryProperty(TEXT("dir"), Vec); }
 
-	// Timestamp of the event using the client's clock by default
-	FORCEINLINE static FTelemetryProperty ClientTimestamp(const FDateTime &Value = FDateTime::UtcNow()) { return FTelemetryProperty("client_ts", Value); }
+    // Timestamp of the event using the client's clock by default
+    FORCEINLINE static FTelemetryProperty ClientTimestamp(const FDateTime &Value = FDateTime::UtcNow()) { return FTelemetryProperty("client_ts", Value); }
 
-	// Unique client id for the device playing the game
-	// Typically set in the Common Properties
-	FORCEINLINE static FTelemetryProperty ClientId(const FString &Value) { return FTelemetryProperty(TEXT("client_id"), Value); }
+    // Unique client id for the device playing the game
+    // Typically set in the Common Properties
+    FORCEINLINE static FTelemetryProperty ClientId(const FString &Value) { return FTelemetryProperty(TEXT("client_id"), Value); }
 
-	// Unique user id for the user playing the game
-	// Typically set in the Common Properties
-	FORCEINLINE static FTelemetryProperty UserId(const FString &Value) { return FTelemetryProperty(TEXT("user_id"), Value); }
+    // Unique user id for the user playing the game
+    // Typically set in the Common Properties
+    FORCEINLINE static FTelemetryProperty UserId(const FString &Value) { return FTelemetryProperty(TEXT("user_id"), Value); }
 
-	// Unique session id for the current play session
-	FORCEINLINE static FTelemetryProperty SessionId(const FString &Value) { return FTelemetryProperty(TEXT("session_id"), Value); }
+    // Unique session id for the current play session
+    FORCEINLINE static FTelemetryProperty SessionId(const FString &Value) { return FTelemetryProperty(TEXT("session_id"), Value); }
 
-	// Semantic version of the telemetry event
-	// Use this to help data pipelines understand how to process the event after ingestion
-	FORCEINLINE static FTelemetryProperty Version(const FString &Value) { return FTelemetryProperty(TEXT("tver"), Value); }
+    // Semantic version of the telemetry event
+    // Use this to help data pipelines understand how to process the event after ingestion
+    FORCEINLINE static FTelemetryProperty Version(const FString &Value) { return FTelemetryProperty(TEXT("tver"), Value); }
 
-	// Semantic version of a component of the telemetry - Typically used by Telemetry Providers
-	// Use this to help data pipelines understand how to process the event after ingestion
-	FORCEINLINE static FTelemetryProperty Version(const FString &SubEntity, const FString &Value) { return FTelemetryProperty(TEXT("tver_") + SubEntity, Value); }
+    // Semantic version of a component of the telemetry - Typically used by Telemetry Providers
+    // Use this to help data pipelines understand how to process the event after ingestion
+    FORCEINLINE static FTelemetryProperty Version(const FString &SubEntity, const FString &Value) { return FTelemetryProperty(TEXT("tver_") + SubEntity, Value); }
 
-	// A value that represents a percentage float between 0 and 100
-	FORCEINLINE static FTelemetryProperty Percentage(const FString &SubEntity, const float &Value)
-	{
-		check(Value >= 0.f && Value <= 100.f);
-		return FTelemetryProperty(TEXT("pct_") + SubEntity, Value);
-	}
+    // A value that represents a percentage float between 0 and 100
+    FORCEINLINE static FTelemetryProperty Percentage(const FString &SubEntity, const float &Value)
+    {
+        check(Value >= 0.f && Value <= 100.f);
+        return FTelemetryProperty(TEXT("pct_") + SubEntity, Value);
+    }
 
-	// A float value
-	FORCEINLINE static FTelemetryProperty Value(const FString &SubEntity, const float &Value) { return FTelemetryProperty(TEXT("val_") + SubEntity, Value);	}
+    // A float value
+    FORCEINLINE static FTelemetryProperty Value(const FString &SubEntity, const float &Value) { return FTelemetryProperty(TEXT("val_") + SubEntity, Value);	}
 
-	// Generic telemetry property maker
-	template<typename T>
-	FORCEINLINE static FTelemetryProperty Prop(const FString &Name, const T &Value) { return FTelemetryProperty(Name, Value); }
+    // Generic telemetry property maker
+    template<typename T>
+    FORCEINLINE static FTelemetryProperty Prop(const FString &Name, const T &Value) { return FTelemetryProperty(Name, Value); }
 
 
 public:
-	// Debug utility function for outputting telemetry to a string for printing
-	static FString DumpJson(FTelemetryProperties Properties);
+    // Debug utility function for outputting telemetry to a string for printing
+    static FString DumpJson(FTelemetryProperties Properties);
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/Telemetry.h
@@ -103,9 +103,6 @@ public:
 	// Orientation unit vector for an entity
 	FORCEINLINE static FTelemetryProperty Orientation(const FVector &Vec) { return FTelemetryProperty(TEXT("dir"), Vec); }
 
-	// The name of the value the visualizer will use
-	FORCEINLINE static FTelemetryProperty DisplayValue(const FString &Value) { return FTelemetryProperty("disp_val", Value); }
-
 	// Timestamp of the event using the client's clock by default
 	FORCEINLINE static FTelemetryProperty ClientTimestamp(const FDateTime &Value = FDateTime::UtcNow()) { return FTelemetryProperty("client_ts", Value); }
 

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryBuilder.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryBuilder.h
@@ -16,56 +16,56 @@
 class GAMETELEMETRY_API FTelemetryBuilder
 {
 public:
-	FTelemetryBuilder() : Properties() {}
+    FTelemetryBuilder() : Properties() {}
 
-	FTelemetryBuilder(FTelemetryProperties &&Properties) : Properties(Properties) {}
-	
-	FTelemetryBuilder(const FTelemetryProperties &Properties) : Properties(Properties) {}
+    FTelemetryBuilder(FTelemetryProperties &&Properties) : Properties(Properties) {}
+    
+    FTelemetryBuilder(const FTelemetryProperties &Properties) : Properties(Properties) {}
 
-	FTelemetryBuilder(FTelemetryPropertiesInitializer InitialProperties) : Properties(InitialProperties)
-	{
-	}
+    FTelemetryBuilder(FTelemetryPropertiesInitializer InitialProperties) : Properties(InitialProperties)
+    {
+    }
 
-	FTelemetryBuilder(const FTelemetryBuilder &Builder) : Properties(Builder.Properties) {}
+    FTelemetryBuilder(const FTelemetryBuilder &Builder) : Properties(Builder.Properties) {}
 
-	~FTelemetryBuilder() {}
+    ~FTelemetryBuilder() {}
 
-	template<typename T>
-	inline void SetProperty(const FString &Name, const T &Value)
-	{
-		Properties.Add(Name, Value);
-	}
+    template<typename T>
+    inline void SetProperty(const FString &Name, const T &Value)
+    {
+        Properties.Add(Name, Value);
+    }
 
-	void SetProperty(const FTelemetryProperty &Property)
-	{
-		Properties.Add(Property.Key, Property.Value);
-	}
-	void SetProperty(FTelemetryProperty &&Property)
-	{
-		Properties.Emplace(MoveTemp(Property.Key), MoveTemp(Property.Value));
-	}
-	void SetProperties(const FTelemetryProperties &OtherProperties)
-	{
-		Properties.Append(OtherProperties);
-	}
+    void SetProperty(const FTelemetryProperty &Property)
+    {
+        Properties.Add(Property.Key, Property.Value);
+    }
+    void SetProperty(FTelemetryProperty &&Property)
+    {
+        Properties.Emplace(MoveTemp(Property.Key), MoveTemp(Property.Value));
+    }
+    void SetProperties(const FTelemetryProperties &OtherProperties)
+    {
+        Properties.Append(OtherProperties);
+    }
 
-	template<typename T>
-	void SetProperty(const FString &Name, T &Value) { SetProperty(FTelemetryProperty(Name, Value)); }
+    template<typename T>
+    void SetProperty(const FString &Name, T &Value) { SetProperty(FTelemetryProperty(Name, Value)); }
 
-	template<typename T>
-	void SetProperty(const FString &&Name, T &&Value) { SetProperty(FTelemetryProperty(Name, Value)); }
+    template<typename T>
+    void SetProperty(const FString &&Name, T &&Value) { SetProperty(FTelemetryProperty(Name, Value)); }
 
-	void SetProperties(FTelemetryPropertiesInitializer InitialProperties) { SetProperties(FTelemetryProperties(InitialProperties)); }
+    void SetProperties(FTelemetryPropertiesInitializer InitialProperties) { SetProperties(FTelemetryProperties(InitialProperties)); }
 
-	void GetPropertiesFromProvider(ITelemetryProvider &Provider)
-	{
-		Provider.ProvideTelemetry(*this);
-	}
+    void GetPropertiesFromProvider(ITelemetryProvider &Provider)
+    {
+        Provider.ProvideTelemetry(*this);
+    }
 
-	const FTelemetryProperties &GetProperties() const { return Properties; }
+    const FTelemetryProperties &GetProperties() const { return Properties; }
 
-	const FVariant & operator[](const FString &Name) const { return Properties[Name]; }
+    const FVariant & operator[](const FString &Name) const { return Properties[Name]; }
 
 private:
-	FTelemetryProperties Properties;
+    FTelemetryProperties Properties;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryInterfaces.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryInterfaces.h
@@ -22,8 +22,8 @@ typedef std::initializer_list<TPairInitializer<const FString &, const FVariant &
 class GAMETELEMETRY_API ITelemetryProvider
 {
 public:
-	virtual ~ITelemetryProvider() {}
+    virtual ~ITelemetryProvider() {}
 
-	// Adds properties to a telemetry builder
-	virtual void ProvideTelemetry(class FTelemetryBuilder &Builder) = 0;
+    // Adds properties to a telemetry builder
+    virtual void ProvideTelemetry(class FTelemetryBuilder &Builder) = 0;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
@@ -85,6 +85,7 @@ public:
 	}
 
 	// Singleton reference
+	// Ensure Initialize is called before this is used
 	static FTelemetryManager &Get() { check(Instance.IsValid()) return *Instance; }
 
 	// Get the currently set client id

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryManager.h
@@ -13,111 +13,112 @@
 #include "CoreMinimal.h"
 #include "TelemetryInterfaces.h"
 #include "TelemetryBuilder.h"
+#include "Containers/CircularQueue.h"
 
 // Storage class for telemetry configuration
 class GAMETELEMETRY_API FTelemetryConfiguration
 {
 public:
-	// URL of the telemetry ingestion server
-	FString IngestionUrl;
+    // URL of the telemetry ingestion server
+    FString IngestionUrl;
 
-	// The interval between flushes
-	double SendInterval = 10.0;
+    // The interval between flushes
+    double SendInterval = 10.0;
 
-	// Number of events that can be pending before events are lost
-	int32 PendingBufferSize = 128;
+    // Number of events that can be pending before events are lost
+    int32 PendingBufferSize = 128;
 
 public:
-	static const FString &GetIniFileName() { return IniFileName; }
-	static const FString &GetIniSectionName() { return IniSectionName; }
+    static const FString &GetIniFileName() { return IniFileName; }
+    static const FString &GetIniSectionName() { return IniSectionName; }
 
-	static bool GetString(const TCHAR *Key, FString &Value) { return GConfig->GetString(*IniSectionName, Key, Value, IniFileName); }
-	static bool GetDouble(const TCHAR *Key, double &Value) { return GConfig->GetDouble(*IniSectionName, Key, Value, IniFileName); }
-	static bool GetInt(const TCHAR *Key, int32 &Value) { return GConfig->GetInt(*IniSectionName, Key, Value, IniFileName); }
+    static bool GetString(const TCHAR *Key, FString &Value) { return GConfig->GetString(*IniSectionName, Key, Value, IniFileName); }
+    static bool GetDouble(const TCHAR *Key, double &Value) { return GConfig->GetDouble(*IniSectionName, Key, Value, IniFileName); }
+    static bool GetInt(const TCHAR *Key, int32 &Value) { return GConfig->GetInt(*IniSectionName, Key, Value, IniFileName); }
 
 private:
-	static FString IniFileName;
-	static FString IniSectionName;
+    static FString IniFileName;
+    static FString IniSectionName;
 };
 
 
 class GAMETELEMETRY_API FTelemetryManager
 {
-	// Singleton for common properties
+    // Singleton for common properties
 public:
-	// Intialization of the singleton fromm the provided configuration
-	static void Initialize(const FTelemetryConfiguration &Config);
+    // Intialization of the singleton fromm the provided configuration
+    static void Initialize(const FTelemetryConfiguration &Config);
 
-	// Helper function to read configuration values from the ini
-	static FTelemetryConfiguration GetConfigFromIni();
+    // Helper function to read configuration values from the ini
+    static FTelemetryConfiguration GetConfigFromIni();
 
-	// Set a new client id - Usually set to the platform client id
-	// If setting this again after initialization, consider flushing existing buffered telemetry or they may be incorrectly associated with the new id
-	void SetClientId(const FString &InClientId);
+    // Set a new client id - Usually set to the platform client id
+    // If setting this again after initialization, consider flushing existing buffered telemetry or they may be incorrectly associated with the new id
+    void SetClientId(const FString &InClientId);
 
-	// Set a new session id - Usually set when the game would like to differentiate between play sessions (such as changing users)
-	// If setting this more than once, consider flushing existing buffered telemetry or they may be incorrectly associated with the new id
-	void SetSessionId(const FString &InSessionId);
+    // Set a new session id - Usually set when the game would like to differentiate between play sessions (such as changing users)
+    // If setting this more than once, consider flushing existing buffered telemetry or they may be incorrectly associated with the new id
+    void SetSessionId(const FString &InSessionId);
 
-	// Set a common property which will be included in all telemetry sent
-	template<typename T>
-	void SetCommonProperty(const FString &Name, const T &Value)
-	{
-		Instance->CommonProperties.SetProperty(Name, Value);
-	}
+    // Set a common property which will be included in all telemetry sent
+    template<typename T>
+    void SetCommonProperty(const FString &Name, const T &Value)
+    {
+        Instance->CommonProperties.SetProperty(Name, Value);
+    }
 
-	// Set a common property which will be included in all telemetry sent
-	void SetCommonProperty(const FTelemetryProperty &Property)
-	{
-		Instance->CommonProperties.SetProperty(Property);
-	}
+    // Set a common property which will be included in all telemetry sent
+    void SetCommonProperty(const FTelemetryProperty &Property)
+    {
+        Instance->CommonProperties.SetProperty(Property);
+    }
 
-	// Set a common property which will be included in all telemetry sent
-	void SetCommonProperty(FTelemetryProperty &&Property)
-	{
-		Instance->CommonProperties.SetProperty(Property);
-	}
+    // Set a common property which will be included in all telemetry sent
+    void SetCommonProperty(FTelemetryProperty &&Property)
+    {
+        Instance->CommonProperties.SetProperty(Property);
+    }
 
-	// Set a common property which will be included in all telemetry sent
-	const FTelemetryProperties &GetCommonProperties()
-	{
-		return Instance->CommonProperties.GetProperties();
-	}
+    // Set a common property which will be included in all telemetry sent
+    const FTelemetryProperties &GetCommonProperties()
+    {
+        return Instance->CommonProperties.GetProperties();
+    }
 
-	// Singleton reference
-	// Ensure Initialize is called before this is used
-	static FTelemetryManager &Get() { check(Instance.IsValid()) return *Instance; }
+    // Singleton reference
+    // Ensure Initialize is called before this is used
+    static FTelemetryManager &Get() { check(Instance.IsValid()) return *Instance; }
 
-	// Get the currently set client id
-	static FString GetClientId() { return Instance->CommonProperties["client_id"].GetValue<FString>(); }
+    // Get the currently set client id
+    static FString GetClientId() { return Instance->CommonProperties["client_id"].GetValue<FString>(); }
 
-	// Get the currently set session id
-	static FString GetSessionId() { return Instance->CommonProperties["session_id"].GetValue<FString>(); }
+    // Get the currently set session id
+    static FString GetSessionId() { return Instance->CommonProperties["session_id"].GetValue<FString>(); }
 
-	/**
-		Records an event and places it in the buffer to be sent
-		@param Name: Event name
-		@param Category: Category
-		@param Version: Semantic version of this event
-		@param PropertiesBuilder: Properties to set in this event
-	*/
-	void Record(const FString &Name, const FString &Category, const FString &Version, FTelemetryBuilder &&PropertiesBuilder);
+    /**
+        Records an event and places it in the buffer to be sent
+        @param Name: Event name
+        @param Category: Category
+        @param Version: Semantic version of this event
+        @param PropertiesBuilder: Properties to set in this event
+    */
+    void Record(const FString &Name, const FString &Category, const FString &Version, FTelemetryBuilder &&PropertiesBuilder);
 
 
-	// Flushes any pending telemetry and shuts down the singleton
-	void Shutdown();
+    // Flushes any pending telemetry and shuts down the singleton
+    void Shutdown();
 
-	~FTelemetryManager() {};
-
-private:
-	FTelemetryManager(FTelemetryConfiguration Configuration) : Configuration(Configuration), CommonProperties() {}
+    ~FTelemetryManager() {};
 
 private:
-	// Singleton instance
-	static TUniquePtr<FTelemetryManager> Instance;
+    FTelemetryManager(FTelemetryConfiguration Configuration) : Configuration(Configuration), CommonProperties() {}
 
 private:
-	// Common properties which are sent with all events
-	FTelemetryBuilder CommonProperties;
-	FTelemetryConfiguration Configuration;
+    // Singleton instance
+    static TUniquePtr<FTelemetryManager> Instance;
+
+private:
+    // Common properties which are sent with all events
+    FTelemetryBuilder CommonProperties;
+    FTelemetryConfiguration Configuration;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryModule.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryModule.h
@@ -18,25 +18,25 @@
  */
 class FTelemetryModule : public IModuleInterface
 {
-	//--------------------------------------------------------------------------
-	// Module functionality
-	//--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    // Module functionality
+    //--------------------------------------------------------------------------
 public:
-	/**
-	 * Singleton-like access to this module's interface.  This is just for convenience!
-	 * Beware of calling this during the shutdown phase, though.  Your module might have been unloaded already.
-	 *
-	 * @return Returns singleton instance, loading the module on demand if needed
-	 */
-	static inline FTelemetryModule& Get()
-	{
-		return FModuleManager::LoadModuleChecked< FTelemetryModule >( "Telemetry" );
-	}
+    /**
+     * Singleton-like access to this module's interface.  This is just for convenience!
+     * Beware of calling this during the shutdown phase, though.  Your module might have been unloaded already.
+     *
+     * @return Returns singleton instance, loading the module on demand if needed
+     */
+    static inline FTelemetryModule& Get()
+    {
+        return FModuleManager::LoadModuleChecked< FTelemetryModule >( "Telemetry" );
+    }
 
-	~FTelemetryModule() {}
-	
+    ~FTelemetryModule() {}
+    
 private:
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
 };
 

--- a/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryService.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetry/Public/TelemetryService.h
@@ -16,31 +16,31 @@
 class GAMETELEMETRY_API FTelemetryService
 {
 public:
-	// The authentication, if used, to authenticate with the Azure Functions
+    // The authentication, if used, to authenticate with the Azure Functions
 
 
-	static TSharedRef<IHttpRequest> CreateServiceRequest()
-	{
-		if (!IsInitialized)
-		{
-			UseKey = FTelemetryConfiguration::GetString(TEXT("AuthenticationKey"), AuthenticationKey);
-			IsInitialized = true;
-		}
+    static TSharedRef<IHttpRequest> CreateServiceRequest()
+    {
+        if (!IsInitialized)
+        {
+            UseKey = FTelemetryConfiguration::GetString(TEXT("AuthenticationKey"), AuthenticationKey);
+            IsInitialized = true;
+        }
 
-		auto request = FHttpModule::Get().CreateRequest();
+        auto request = FHttpModule::Get().CreateRequest();
 
-		// @todo: Add any other common http request initialization code here
+        // @todo: Add any other common http request initialization code here
 
-		if (UseKey)
-		{
-			// https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook#api-key-authorization
-			request->SetHeader(TEXT("x-functions-key"), AuthenticationKey);
-		}
-		return request;
-	}
+        if (UseKey)
+        {
+            // https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook#api-key-authorization
+            request->SetHeader(TEXT("x-functions-key"), AuthenticationKey);
+        }
+        return request;
+    }
 
 private:
-	static FString AuthenticationKey;
-	static bool UseKey;
-	static bool IsInitialized;
+    static FString AuthenticationKey;
+    static bool UseKey;
+    static bool IsInitialized;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
@@ -20,21 +20,21 @@ struct STelemetryEvent;
 //Type of mesh to draw for an event
 static enum EventType
 {
-	Cone,
-	Cube,
-	Cylinder,
-	Plane,
-	Sphere
+    Cone,
+    Cube,
+    Cylinder,
+    Plane,
+    Sphere
 };
 
 //Structure for rendering information
 struct InstanceType
 {
-	UInstancedStaticMeshComponent* component;
-	FColor color;
-	EventType type;
+    UInstancedStaticMeshComponent* component;
+    FColor color;
+    EventType type;
 
-	InstanceType(UInstancedStaticMeshComponent* component, FColor color, EventType type) : component(component), color(color), type(type) {}
+    InstanceType(UInstancedStaticMeshComponent* component, FColor color, EventType type) : component(component), color(color), type(type) {}
 };
 
 UCLASS()
@@ -45,89 +45,89 @@ class ATelemetryEvent : public AActor
 public:
     ATelemetryEvent(const FObjectInitializer& InInitializer);
 
-	//Name and category of event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Event"))
-	FString eventName;
+    //Name and category of event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Event"))
+    FString eventName;
 
-	//Location of an event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Location"))
-	FVector location;
+    //Location of an event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Location"))
+    FVector location;
 
-	//Orientation of an event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Orientation"))
-	FVector orientation;
+    //Orientation of an event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Orientation"))
+    FVector orientation;
 
-	//Client time of the event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Time"))
-	FDateTime time;
+    //Client time of the event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Time"))
+    FDateTime time;
 
-	//Value for an event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Value"))
-	TMap<FString, FString> values;
+    //Value for an event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Value"))
+    TMap<FString, FString> values;
 
-	//Session of the event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Session ID"))
-	FString session;
+    //Session of the event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Session ID"))
+    FString session;
 
-	//User ID of the event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "User"))
-	FString user;
+    //User ID of the event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "User"))
+    FString user;
 
-	//Build string of the event
-	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Build"))
-	FString build;
+    //Build string of the event
+    UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Build"))
+    FString build;
 
-	TArray<InstanceType> InstanceTypes;
+    TArray<InstanceType> InstanceTypes;
 
-	//Populates event values based on an Telemetry event
-	void SetEvent(const TSharedPtr<STelemetryEvent> inPointer);
+    //Populates event values based on an Telemetry event
+    void SetEvent(const TSharedPtr<STelemetryEvent> inPointer);
 
-	//Sets the emissive color of the mesh
-	void SetColor(FColor inColor);
+    //Sets the emissive color of the mesh
+    void SetColor(FColor inColor);
 
-	//Set the shape of the mesh
-	void SetShapeType(EventType inType);
+    //Set the shape of the mesh
+    void SetShapeType(EventType inType);
 
-	//Set size of the mesh
-	void SetScale(float inScale);
+    //Set size of the mesh
+    void SetScale(float inScale);
 
-	//Set the value and range
-	void AddValue(FString name, FString value) { values.Add(name, value); }
+    //Set the value and range
+    void AddValue(FString inName, FString value) { values.Add(inName, value); }
 
-	//Return the private name or category
-	FString GetName() { return name; }
-	FString GetCategory() { return category; }
+    //Return the private name or category
+    FString GetName() { return eventName; }
+    FString GetCategory() { return category; }
 
-	bool IsEditorOnly() const { return true; };
+    bool IsEditorOnly() const { return true; };
 
-	//Build the render details of this actor based on event details
-	void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType)
-	{
-		AddEvent(inLocation, inOrientation, inColor, inType, scale, 2.f);
-	};
+    //Build the render details of this actor based on event details
+    void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType)
+    {
+        AddEvent(inLocation, inOrientation, inColor, inType, FBox::BuildAABB(FVector::ZeroVector, scale), L"Mesh");
+    };
 
-	void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, float inScale, float ratio)
-	{
-		AddEvent(inLocation, inOrientation, inColor, inType, FBox::BuildAABB(FVector::ZeroVector, FVector(inScale, inScale, inScale)), ratio);
-	};
+    void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, float inScale, double ratio)
+    {
+        AddEvent(inLocation, inOrientation, inColor, inType, FBox::BuildAABB(FVector::ZeroVector, FVector(inScale, inScale, inScale)), ratio);
+    };
 
-	void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FVector inScale, float ratio)
-	{
-		AddEvent(inLocation, inOrientation, inColor, inType, FBox::BuildAABB(FVector::ZeroVector, inScale), ratio);
-	};
+    void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FBox inScale, double ratio)
+    {
+        AddEvent(inLocation, inOrientation, inColor, inType, inScale, "HeatmapGroup_" + FString::SanitizeFloat(ratio));
+    };
 
-	void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FBox inScale, float ratio);
+    void AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FBox inScale, FString inName);
 
 private:
 //Cached mesh and material instances
-	UStaticMesh* MeshCone;
-	UStaticMesh* MeshCube;
-	UStaticMesh* MeshCylinder;
-	UStaticMesh* MeshPlane;
-	UStaticMesh* MeshSphere;
-	UMaterial* MeshMaterial;
+    UStaticMesh* MeshCone;
+    UStaticMesh* MeshCube;
+    UStaticMesh* MeshCylinder;
+    UStaticMesh* MeshPlane;
+    UStaticMesh* MeshSphere;
+    UMaterial* MeshMaterial;
 
-	FVector scale;
-	FString name;
-	FString category;
+    FVector scale;
+    FString name;
+    FString category;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetryEvent.h
@@ -63,7 +63,7 @@ public:
 
 	//Value for an event
 	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Value"))
-    float value;
+	TMap<FString, FString> values;
 
 	//Session of the event
 	UPROPERTY(VisibleAnywhere, Category = "TelemetryEvent", Meta = (ToolTip = "Session ID"))
@@ -92,7 +92,7 @@ public:
 	void SetScale(float inScale);
 
 	//Set the value and range
-	void SetValue(float inValue) { value = inValue; }
+	void AddValue(FString name, FString value) { values.Add(name, value); }
 
 	//Return the private name or category
 	FString GetName() { return name; }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetrySettings.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Classes/TelemetrySettings.h
@@ -19,57 +19,57 @@
 USTRUCT()
 struct FTelemetryConfigSetting
 {
-	GENERATED_USTRUCT_BODY()
+    GENERATED_USTRUCT_BODY()
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FString QueryUrl;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FString QueryUrl;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FString IngestUrl;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FString IngestUrl;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	int32 SendInterval;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    int32 SendInterval;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	int32 MaxBufferSize;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    int32 MaxBufferSize;
 
-	UPROPERTY(EditAnywhere, Category = Telemetry, meta = (ConfigRestartRequired = true))
-	int32 QueryTakeLimit;
+    UPROPERTY(EditAnywhere, Category = Telemetry, meta = (ConfigRestartRequired = true))
+    int32 QueryTakeLimit;
 
-	UPROPERTY(EditAnywhere, Category = Telemetry, meta = (ConfigRestartRequired = true))
-	FString AuthenticationKey;
+    UPROPERTY(EditAnywhere, Category = Telemetry, meta = (ConfigRestartRequired = true))
+    FString AuthenticationKey;
 };
 
 UCLASS()
 class UTelemetrySettings
-	: public UAnalyticsSettingsBase
+    : public UAnalyticsSettingsBase
 {
-	GENERATED_UCLASS_BODY()
+    GENERATED_UCLASS_BODY()
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FTelemetryConfigSetting Release;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FTelemetryConfigSetting Release;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FTelemetryConfigSetting Debug;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FTelemetryConfigSetting Debug;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FTelemetryConfigSetting Test;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FTelemetryConfigSetting Test;
 
-	UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
-	FTelemetryConfigSetting Development;
+    UPROPERTY(EditAnywhere, Category=Telemetry, meta=(ConfigRestartRequired=true))
+    FTelemetryConfigSetting Development;
 
 // UTelemetrySettingsBase interface
 protected:
-	/**
-	 * Provides a mechanism to read the section based information into this UObject's properties
-	 */
-	virtual void ReadConfigSettings();
-	/**
-	 * Provides a mechanism to save this object's properties to the section based ini values
-	 */
-	virtual void WriteConfigSettings();
+    /**
+     * Provides a mechanism to read the section based information into this UObject's properties
+     */
+    virtual void ReadConfigSettings();
+    /**
+     * Provides a mechanism to save this object's properties to the section based ini values
+     */
+    virtual void WriteConfigSettings();
 
 private:
-	void ReadConfigStruct(const FString& Section, FTelemetryConfigSetting& Dest, FTelemetryConfigSetting* Default = nullptr);
-	void WriteConfigStruct(const FString& Section, const FTelemetryConfigSetting& Source);
+    void ReadConfigStruct(const FString& Section, FTelemetryConfigSetting& Dest, FTelemetryConfigSetting* Default = nullptr);
+    void WriteConfigStruct(const FString& Section, const FTelemetryConfigSetting& Source);
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
@@ -165,7 +165,6 @@ void ATelemetryEvent::SetEvent(const TSharedPtr<STelemetryEvent> inPointer)
 	if (InstanceTypes.Num() != 1) return;
 
 	time = inPointer->time;
-	value = inPointer->value;
 	location = inPointer->point;
 	session = inPointer->session;
 	orientation = inPointer->orientation;
@@ -173,6 +172,11 @@ void ATelemetryEvent::SetEvent(const TSharedPtr<STelemetryEvent> inPointer)
 	build = inPointer->build;
 	name = inPointer->name;
 	category = inPointer->category;
+
+	for (auto& value : inPointer->values)
+	{
+		values.Add(value.Key, value.Value->AsString());
+	}
 
 	eventName = category + L" " + name;
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryEvent.cpp
@@ -18,223 +18,212 @@
 ATelemetryEvent::ATelemetryEvent(const FObjectInitializer& InInitializer)
 : AActor(InInitializer)
 {
-	//Cannot move this actor or interact in play
-	bLockLocation = true;
-	bCanBeDamaged = false;
-	bIsEditorOnlyActor = true;
-	SetActorEnableCollision(false);
+    //Cannot move this actor or interact in play
+    bLockLocation = true;
+    bCanBeDamaged = false;
+    bIsEditorOnlyActor = true;
+    SetActorEnableCollision(false);
 
-	//Default scale
-	scale = FVector(0.5f);
+    //Default scale
+    scale = FVector(0.5f);
 
-	//Cache pointer for material
-	static ConstructorHelpers::FObjectFinder<UMaterial> MaterialAsset(TEXT("/GameTelemetry/Materials/M_Telemetry.M_Telemetry"));
-	if (MaterialAsset.Succeeded())
-	{
-		MeshMaterial = MaterialAsset.Object;
-	}
+    //Cache pointer for material
+    static ConstructorHelpers::FObjectFinder<UMaterial> MaterialAsset(TEXT("/GameTelemetry/Materials/M_Telemetry.M_Telemetry"));
+    if (MaterialAsset.Succeeded())
+    {
+        MeshMaterial = MaterialAsset.Object;
+    }
 
-	//Cache pointers each possible mesh.  This call is required to be in the constructor
-	ConstructorHelpers::FObjectFinder<UStaticMesh> MeshConeAsset(TEXT("/Engine/BasicShapes/Cone.Cone"));
-	ConstructorHelpers::FObjectFinder<UStaticMesh> MeshCubeAsset(TEXT("/Engine/BasicShapes/Cube.Cube"));
-	ConstructorHelpers::FObjectFinder<UStaticMesh> MeshCylinderAsset(TEXT("/Engine/BasicShapes/Cylinder.Cylinder"));
-	ConstructorHelpers::FObjectFinder<UStaticMesh> MeshPlaneAsset(TEXT("/Engine/BasicShapes/Plane.Plane"));
-	ConstructorHelpers::FObjectFinder<UStaticMesh> MeshSphereAsset(TEXT("/Engine/BasicShapes/Sphere.Sphere"));
+    //Cache pointers each possible mesh.  This call is required to be in the constructor
+    ConstructorHelpers::FObjectFinder<UStaticMesh> MeshConeAsset(TEXT("/Engine/BasicShapes/Cone.Cone"));
+    ConstructorHelpers::FObjectFinder<UStaticMesh> MeshCubeAsset(TEXT("/Engine/BasicShapes/Cube.Cube"));
+    ConstructorHelpers::FObjectFinder<UStaticMesh> MeshCylinderAsset(TEXT("/Engine/BasicShapes/Cylinder.Cylinder"));
+    ConstructorHelpers::FObjectFinder<UStaticMesh> MeshPlaneAsset(TEXT("/Engine/BasicShapes/Plane.Plane"));
+    ConstructorHelpers::FObjectFinder<UStaticMesh> MeshSphereAsset(TEXT("/Engine/BasicShapes/Sphere.Sphere"));
 
-	if (MeshConeAsset.Succeeded())
-	{
-		MeshCone = MeshConeAsset.Object;
-	}
-	if (MeshCubeAsset.Succeeded())
-	{
-		MeshCube = MeshCubeAsset.Object;
-	}
-	if (MeshCylinderAsset.Succeeded())
-	{
-		MeshCylinder = MeshCylinderAsset.Object;
-	}
-	if (MeshPlaneAsset.Succeeded())
-	{
-		MeshPlane = MeshPlaneAsset.Object;
-	}
-	if (MeshSphereAsset.Succeeded())
-	{
-		MeshSphere = MeshSphereAsset.Object;
-	}
+    if (MeshConeAsset.Succeeded())
+    {
+        MeshCone = MeshConeAsset.Object;
+    }
+    if (MeshCubeAsset.Succeeded())
+    {
+        MeshCube = MeshCubeAsset.Object;
+    }
+    if (MeshCylinderAsset.Succeeded())
+    {
+        MeshCylinder = MeshCylinderAsset.Object;
+    }
+    if (MeshPlaneAsset.Succeeded())
+    {
+        MeshPlane = MeshPlaneAsset.Object;
+    }
+    if (MeshSphereAsset.Succeeded())
+    {
+        MeshSphere = MeshSphereAsset.Object;
+    }
 }
 
-void ATelemetryEvent::AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FBox inScale, float ratio)
+void ATelemetryEvent::AddEvent(FVector inLocation, FVector inOrientation, FColor inColor, EventType inType, FBox inScale, FString inName)
 {
-	UInstancedStaticMeshComponent* NewComponent = nullptr;
+    UInstancedStaticMeshComponent* NewComponent = nullptr;
 
-	scale = inScale.GetExtent();
+    scale = inScale.GetExtent();
 
-	for (int i = 0; i < InstanceTypes.Num(); i++)
-	{
-		if (inColor == InstanceTypes[i].color && inType == InstanceTypes[i].type)
-		{
-			NewComponent = InstanceTypes[i].component;
-		}
-	}
+    for (int i = 0; i < InstanceTypes.Num(); i++)
+    {
+        if (inColor == InstanceTypes[i].color && inType == InstanceTypes[i].type)
+        {
+            NewComponent = InstanceTypes[i].component;
+        }
+    }
 
-	FString tempName;
+    if (NewComponent == nullptr)
+    {
+        if (GetRootComponent())
+        {
+            // Attach to root if we already have one
+            NewComponent->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+        }
+        else
+        {
+            // Make a new root if we dont have a root already
+            SetRootComponent(NewComponent);
+        }
 
-	if (NewComponent == nullptr)
-	{
-		if (GetRootComponent())
-		{
-			// Attach to root if we already have one
-			NewComponent->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
-		}
-		else
-		{
-			// Make a new root if we dont have a root already
-			SetRootComponent(NewComponent);
-		}
+        NewComponent = NewObject<UInstancedStaticMeshComponent>(this, *inName);
 
-		if (ratio < 2.f)
-		{
-			tempName = "HeatmapGroup_" + FString::SanitizeFloat(ratio);
-		}
-		else
-		{
-			tempName = "Mesh";
-		}
+        //Set mesh
+        UStaticMesh* newMesh = nullptr;
 
-		NewComponent = NewObject<UInstancedStaticMeshComponent>(this, *tempName);
+        switch (inType)
+        {
+        case EventType::Cone:
+            newMesh = MeshCone;
+            break;
+        case EventType::Cube:
+            newMesh = MeshCube;
+            break;
+        case EventType::Cylinder:
+            newMesh = MeshCylinder;
+            break;
+        case EventType::Plane:
+            newMesh = MeshPlane;
+            break;
+        case EventType::Sphere:
+            newMesh = MeshSphere;
+            break;
+        }
 
-		//Set mesh
-		UStaticMesh* newMesh = nullptr;
+        if (newMesh != nullptr)
+        {
+            NewComponent->SetStaticMesh(newMesh);
+            NewComponent->SetWorldScale3D(scale);
+        }
 
-		switch (inType)
-		{
-		case EventType::Cone:
-			newMesh = MeshCone;
-			break;
-		case EventType::Cube:
-			newMesh = MeshCube;
-			break;
-		case EventType::Cylinder:
-			newMesh = MeshCylinder;
-			break;
-		case EventType::Plane:
-			newMesh = MeshPlane;
-			break;
-		case EventType::Sphere:
-			newMesh = MeshSphere;
-			break;
-		}
+        //Set material
+        UMaterialInstanceDynamic* matInstance = NewComponent->CreateDynamicMaterialInstance(0, MeshMaterial);
 
-		if (newMesh != nullptr)
-		{
-			NewComponent->SetStaticMesh(newMesh);
-			NewComponent->SetWorldScale3D(scale);
-		}
+        if (matInstance != nullptr)
+        {
+            matInstance->SetVectorParameterValue("Color", FLinearColor(inColor));
+            NewComponent->SetMaterial(0, matInstance);
+        }
 
-		//Set material
-		UMaterialInstanceDynamic* matInstance = NewComponent->CreateDynamicMaterialInstance(0, MeshMaterial);
+        // Take 'instanced' ownership so it persists with this actor
+        RemoveOwnedComponent(NewComponent);
+        NewComponent->CreationMethod = EComponentCreationMethod::Instance;
+        AddOwnedComponent(NewComponent);
+        
+        NewComponent->RegisterComponent();
 
-		if (matInstance != nullptr)
-		{
-			matInstance->SetVectorParameterValue("Color", FLinearColor(inColor));
-			NewComponent->SetMaterial(0, matInstance);
-		}
+        InstanceTypes.Add(InstanceType(NewComponent, inColor, inType));
+    }
 
-		// Take 'instanced' ownership so it persists with this actor
-		RemoveOwnedComponent(NewComponent);
-		NewComponent->CreationMethod = EComponentCreationMethod::Instance;
-		AddOwnedComponent(NewComponent);
-		
-		NewComponent->RegisterComponent();
+    FRotator tempRot = FRotator::ZeroRotator;
+    if (inOrientation != FVector::ZeroVector)
+    {
+        tempRot = inOrientation.ToOrientationRotator();
+        tempRot.Pitch -= 90.f;
+    }
 
-		InstanceTypes.Add(InstanceType(NewComponent, inColor, inType));
-	}
-
-	FRotator tempRot = FRotator::ZeroRotator;
-	if (inOrientation != FVector::ZeroVector)
-	{
-		tempRot = inOrientation.ToOrientationRotator();
-		tempRot.Pitch -= 90.f;
-	}
-
-	NewComponent->AddInstanceWorldSpace(FTransform(tempRot, inLocation + inScale.GetCenter(), scale));
+    NewComponent->AddInstanceWorldSpace(FTransform(tempRot, inLocation + inScale.GetCenter(), scale));
 }
 
 void ATelemetryEvent::SetEvent(const TSharedPtr<STelemetryEvent> inPointer)
 {
-	if (InstanceTypes.Num() != 1) return;
+    if (InstanceTypes.Num() != 1) return;
 
-	time = inPointer->time;
-	location = inPointer->point;
-	session = inPointer->session;
-	orientation = inPointer->orientation;
-	user = inPointer->user;
-	build = inPointer->build;
-	name = inPointer->name;
-	category = inPointer->category;
+    time = inPointer->time;
+    location = inPointer->point;
+    session = inPointer->session;
+    orientation = inPointer->orientation;
+    user = inPointer->user;
+    build = inPointer->build;
+    name = inPointer->eventname;
+    category = inPointer->category;
 
-	for (auto& value : inPointer->values)
-	{
-		values.Add(value.Key, value.Value->AsString());
-	}
+    for (auto& value : inPointer->values)
+    {
+        values.Add(value.Key, value.Value->AsString());
+    }
 
-	eventName = category + L" " + name;
+    eventName = category + L" " + name;
 }
 
 void ATelemetryEvent::SetColor(FColor inColor)
 {
-	if (InstanceTypes.Num() != 1) return;
+    if (InstanceTypes.Num() != 1) return;
 
-	UMaterialInterface * Material;
-	UMaterialInstanceDynamic* matInstance;
+    UMaterialInterface * Material;
+    UMaterialInstanceDynamic* matInstance;
 
-	Material = InstanceTypes[0].component->GetMaterial(0);
-	matInstance = InstanceTypes[0].component->CreateDynamicMaterialInstance(0, Material);
+    Material = InstanceTypes[0].component->GetMaterial(0);
+    matInstance = InstanceTypes[0].component->CreateDynamicMaterialInstance(0, Material);
 
-	if (matInstance != nullptr)
-	{
-		matInstance->SetVectorParameterValue("Color", FLinearColor(inColor));
-		InstanceTypes[0].component->SetMaterial(0, matInstance);
-	}
+    if (matInstance != nullptr)
+    {
+        matInstance->SetVectorParameterValue("Color", FLinearColor(inColor));
+        InstanceTypes[0].component->SetMaterial(0, matInstance);
+    }
 };
 
 void ATelemetryEvent::SetShapeType(EventType inType)
 {
-	if (InstanceTypes.Num() != 1) return;
+    if (InstanceTypes.Num() != 1) return;
 
-	UStaticMesh* newMesh = nullptr;
+    UStaticMesh* newMesh = nullptr;
 
-	switch (inType)
-	{
-	case EventType::Cone:
-		newMesh = MeshCone;
-		break;
-	case EventType::Cube:
-		newMesh = MeshCube;
-		break;
-	case EventType::Cylinder:
-		newMesh = MeshCylinder;
-		break;
-	case EventType::Plane:
-		newMesh = MeshPlane;
-		break;
-	case EventType::Sphere:
-		newMesh = MeshSphere;
-		break;
-	}
+    switch (inType)
+    {
+    case EventType::Cone:
+        newMesh = MeshCone;
+        break;
+    case EventType::Cube:
+        newMesh = MeshCube;
+        break;
+    case EventType::Cylinder:
+        newMesh = MeshCylinder;
+        break;
+    case EventType::Plane:
+        newMesh = MeshPlane;
+        break;
+    case EventType::Sphere:
+        newMesh = MeshSphere;
+        break;
+    }
 
-	if (newMesh != nullptr)
-	{
-		InstanceTypes[0].component->SetStaticMesh(newMesh);
-		InstanceTypes[0].component->SetWorldScale3D(scale);
-	}
+    if (newMesh != nullptr)
+    {
+        InstanceTypes[0].component->SetStaticMesh(newMesh);
+        InstanceTypes[0].component->SetWorldScale3D(scale);
+    }
 }
 
 void ATelemetryEvent::SetScale(float inScale)
 {
-	if (InstanceTypes.Num() != 1) return;
+    if (InstanceTypes.Num() != 1) return;
 
-	scale = FVector(inScale);
+    scale = FVector(inScale);
 
-	InstanceTypes[0].component->SetWorldScale3D(scale);
+    InstanceTypes[0].component->SetWorldScale3D(scale);
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryQuery.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryQuery.cpp
@@ -18,23 +18,23 @@
 // See: EQueryNodeType
 static const FQueryNodeType NodeTypeStrings[] =
 {
-	"comparison",
-	"group"
+    "comparison",
+    "group"
 };
 
 // See: EQueryOp
 static const FQueryOperator QueryOpStrings[] =
 {
-	"eq",
-	"gt",
-	"gte",
-	"lt",
-	"lte",
-	"neq",
-	"in",
-	"btwn",
-	"and",
-	"or",
+    "eq",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "neq",
+    "in",
+    "btwn",
+    "and",
+    "or",
 };
 
 static inline const FQueryOperator &GetOp(EQueryOp Op) { return QueryOpStrings[(int)Op]; }
@@ -42,83 +42,83 @@ static inline const FQueryOperator &GetType(EQueryNodeType Type) { return NodeTy
 
 FString FQuerySerializer::Serialize(const FQueryNodePtr Node)
 {
-	FString Payload;
-	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Payload);
+    FString Payload;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Payload);
 
 
-	Serialize(Node, Writer);
+    Serialize(Node, Writer);
 
-	Writer->Close();
+    Writer->Close();
 
-	return Payload;
+    return Payload;
 }
 
 void WriteValue(const TSharedPtr<FJsonValue> &Value, TSharedRef<TJsonWriter<>> &Writer)
 {
-	switch (Value->Type)
-	{
-	case EJson::Number:
-		Writer->WriteValue("value", Value->AsNumber());
-		break;
-	case EJson::String:
-		Writer->WriteValue("value", Value->AsString());
-		break;
-	case EJson::Boolean:
-		Writer->WriteValue("value", Value->AsBool());
-		break;
-	case EJson::Array:
-		Writer->WriteArrayStart("values");
-		for (const TSharedPtr<FJsonValue> &Item : Value->AsArray())
-		{
-			switch (Item->Type)
-			{
-			case EJson::Number:
-				Writer->WriteValue(Item->AsNumber());
-				break;
-			case EJson::String:
-				Writer->WriteValue(Item->AsString());
-				break;
-			case EJson::Boolean:
-				Writer->WriteValue(Item->AsBool());
-				break;
-			}
-		}
-		Writer->WriteArrayEnd();
-		break;
-	}
+    switch (Value->Type)
+    {
+    case EJson::Number:
+        Writer->WriteValue("value", Value->AsNumber());
+        break;
+    case EJson::String:
+        Writer->WriteValue("value", Value->AsString());
+        break;
+    case EJson::Boolean:
+        Writer->WriteValue("value", Value->AsBool());
+        break;
+    case EJson::Array:
+        Writer->WriteArrayStart("values");
+        for (const TSharedPtr<FJsonValue> &Item : Value->AsArray())
+        {
+            switch (Item->Type)
+            {
+            case EJson::Number:
+                Writer->WriteValue(Item->AsNumber());
+                break;
+            case EJson::String:
+                Writer->WriteValue(Item->AsString());
+                break;
+            case EJson::Boolean:
+                Writer->WriteValue(Item->AsBool());
+                break;
+            }
+        }
+        Writer->WriteArrayEnd();
+        break;
+    }
 }
 
 
 void FQuerySerializer::Serialize(const FQueryNodePtr &Node, TSharedRef<TJsonWriter<>> &Writer)
 {
-	Writer->WriteObjectStart();
-	Writer->WriteValue("type", GetType(Node->Type));
-	Writer->WriteValue("op", GetOp(Node->Operator));
-	{
-		switch (Node->Type)
-		{
-		case EQueryNodeType::Group:
-			Serialize(*(Node->Children), Writer);
-			break;
+    Writer->WriteObjectStart();
+    Writer->WriteValue("type", GetType(Node->Type));
+    Writer->WriteValue("op", GetOp(Node->Operator));
+    {
+        switch (Node->Type)
+        {
+        case EQueryNodeType::Group:
+            Serialize(*(Node->Children), Writer);
+            break;
 
-		case EQueryNodeType::Comparison:
-			Writer->WriteValue("column", Node->Column);
-			WriteValue(Node->Value, Writer);
-			break;
-		}
-	}
-	Writer->WriteObjectEnd();
+        case EQueryNodeType::Comparison:
+            Writer->WriteValue("column", Node->Column);
+            WriteValue(Node->Value, Writer);
+            break;
+        }
+    }
+    Writer->WriteObjectEnd();
 }
 
 void FQuerySerializer::Serialize(FQueryNodeList &Nodes, TSharedRef<TJsonWriter<>> &Writer)
 {
-	Writer->WriteArrayStart("children");
-	{
-		for (FQueryNodePtr Item : Nodes)
-		{
-			Serialize(Item, Writer);
-		}
-	}
-	Writer->WriteArrayEnd();
+    Writer->WriteArrayStart("children");
+    {
+        for (FQueryNodePtr Item : Nodes)
+        {
+            Serialize(Item, Writer);
+        }
+    }
+    Writer->WriteArrayEnd();
 }
 

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetrySettings.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetrySettings.cpp
@@ -15,133 +15,133 @@
 #define LOCTEXT_NAMESPACE "Telemetry"
 
 UTelemetrySettings::UTelemetrySettings(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+    : Super(ObjectInitializer)
 {
-	SettingsDisplayName = LOCTEXT("SettingsDisplayName", "Telemetry");
-	SettingsTooltip = LOCTEXT("SettingsTooltip", "Telemetry configuration settings");
+    SettingsDisplayName = LOCTEXT("SettingsDisplayName", "Telemetry");
+    SettingsTooltip = LOCTEXT("SettingsTooltip", "Telemetry configuration settings");
 }
 
 FTelemetryConfigSetting GetDefaultSettings()
 {
-	FTelemetryConfigSetting Default;
-	Default.IngestUrl = "https://<yourazurefunctionapp>.azurewebsites.net/api/ingest";
-	Default.QueryUrl = "https://<yourazurefunctionapp>.azurewebsites.net/api/query";
-	Default.MaxBufferSize = 128;
-	Default.SendInterval = 60;
-	Default.QueryTakeLimit = 10000;
-	Default.AuthenticationKey = "<Enter your Azure Functions authentication key here>";
+    FTelemetryConfigSetting Default;
+    Default.IngestUrl = "https://<yourazurefunctionapp>.azurewebsites.net/api/ingest";
+    Default.QueryUrl = "https://<yourazurefunctionapp>.azurewebsites.net/api/query";
+    Default.MaxBufferSize = 128;
+    Default.SendInterval = 60;
+    Default.QueryTakeLimit = 10000;
+    Default.AuthenticationKey = "<Enter your Azure Functions authentication key here>";
 
-	return Default;
+    return Default;
 }
 
 void UTelemetrySettings::ReadConfigSettings()
 {
-	FTelemetryConfigSetting DefaultSettings = GetDefaultSettings();
+    FTelemetryConfigSetting DefaultSettings = GetDefaultSettings();
 
-	ReadConfigStruct(GetDevelopmentIniSection(), Development, &DefaultSettings);
-	ReadConfigStruct(GetReleaseIniSection(), Release, &Development);
-	ReadConfigStruct(GetTestIniSection(), Test, &Development);
-	ReadConfigStruct(GetDebugIniSection(), Debug, &Development);
+    ReadConfigStruct(GetDevelopmentIniSection(), Development, &DefaultSettings);
+    ReadConfigStruct(GetReleaseIniSection(), Release, &Development);
+    ReadConfigStruct(GetTestIniSection(), Test, &Development);
+    ReadConfigStruct(GetDebugIniSection(), Debug, &Development);
 }
 
 void UTelemetrySettings::WriteConfigSettings()
 {
-	WriteConfigStruct(GetReleaseIniSection(), Release);
-	WriteConfigStruct(GetTestIniSection(), Test);
-	WriteConfigStruct(GetDebugIniSection(), Debug);
-	WriteConfigStruct(GetDevelopmentIniSection(), Development);
+    WriteConfigStruct(GetReleaseIniSection(), Release);
+    WriteConfigStruct(GetTestIniSection(), Test);
+    WriteConfigStruct(GetDebugIniSection(), Debug);
+    WriteConfigStruct(GetDevelopmentIniSection(), Development);
 }
 
 FString GetConfigValueFromIni(const FString &KeyName, bool IsRequired)
 {
-	const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
-	const FString SectionName = "GameTelemetry";
+    const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
+    const FString SectionName = "GameTelemetry";
 
-	FString Result;
-	bool Success = GConfig->GetString(*SectionName, *KeyName, Result, IniName);
+    FString Result;
+    bool Success = GConfig->GetString(*SectionName, *KeyName, Result, IniName);
 
-	// Don't error if the configuration file isn't created yet.  Let the editor help make it!
-	if (IsRequired && FPaths::FileExists(IniName))
-	{
-		check(Success);
-	}
-	return Result;
+    // Don't error if the configuration file isn't created yet.  Let the editor help make it!
+    if (IsRequired && FPaths::FileExists(IniName))
+    {
+        check(Success);
+    }
+    return Result;
 }
 
 void SetConfigValueFromIni(const FString &KeyName, const FString &Value)
 {
-	const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
-	const FString SectionName = "GameTelemetry";
+    const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
+    const FString SectionName = "GameTelemetry";
 
-	GConfig->SetString(*SectionName, *KeyName, *Value, IniName);
+    GConfig->SetString(*SectionName, *KeyName, *Value, IniName);
 }
 
 void UTelemetrySettings::ReadConfigStruct(const FString& Section, FTelemetryConfigSetting& Dest, FTelemetryConfigSetting* Default)
 {
-	const FString QueryUrl = GetConfigValueFromIni(TEXT("QueryUrl"), true);
-	if (QueryUrl.Len() == 0 && Default != nullptr)
-	{
-		Dest.QueryUrl = Default->QueryUrl;
-	}
-	else
-	{
-		Dest.QueryUrl = QueryUrl;
-	}
-	const FString IngestUrl = GetConfigValueFromIni(TEXT("IngestUrl"), true);
-	if (IngestUrl.Len() == 0 && Default != nullptr)
-	{
-		Dest.IngestUrl = Default->IngestUrl;
-	}
-	else
-	{
-		Dest.IngestUrl = IngestUrl;
-	}
-	const FString SendInterval = GetConfigValueFromIni(TEXT("SendInterval"), false);
-	if (SendInterval.Len() == 0 && Default != nullptr)
-	{
-		Dest.SendInterval = Default->SendInterval;
-	}
-	else
-	{
-		Dest.SendInterval = FCString::Atoi(*SendInterval);
-	}
-	const FString MaxBufferSize = GetConfigValueFromIni(TEXT("MaxBufferSize"), false);
-	if (MaxBufferSize.Len() == 0 && Default != nullptr)
-	{
-		Dest.MaxBufferSize = Default->MaxBufferSize;
-	}
-	else
-	{
-		Dest.MaxBufferSize = FCString::Atoi(*MaxBufferSize);
-	}
-	const FString QueryTakeLimit = GetConfigValueFromIni(TEXT("QueryTakeLimit"), false);
-	if (QueryTakeLimit.Len() == 0 && Default != nullptr)
-	{
-		Dest.QueryTakeLimit = Default->QueryTakeLimit;
-	}
-	else
-	{
-		Dest.QueryTakeLimit = FCString::Atoi(*QueryTakeLimit);
-	}
-	const FString AuthenticationKey = GetConfigValueFromIni(TEXT("AuthenticationKey"), false);
-	if (AuthenticationKey.Len() == 0 && Default != nullptr)
-	{
-		Dest.AuthenticationKey = Default->AuthenticationKey;
-	}
-	else
-	{
-		Dest.AuthenticationKey = AuthenticationKey;
-	}
+    const FString QueryUrl = GetConfigValueFromIni(TEXT("QueryUrl"), true);
+    if (QueryUrl.Len() == 0 && Default != nullptr)
+    {
+        Dest.QueryUrl = Default->QueryUrl;
+    }
+    else
+    {
+        Dest.QueryUrl = QueryUrl;
+    }
+    const FString IngestUrl = GetConfigValueFromIni(TEXT("IngestUrl"), true);
+    if (IngestUrl.Len() == 0 && Default != nullptr)
+    {
+        Dest.IngestUrl = Default->IngestUrl;
+    }
+    else
+    {
+        Dest.IngestUrl = IngestUrl;
+    }
+    const FString SendInterval = GetConfigValueFromIni(TEXT("SendInterval"), false);
+    if (SendInterval.Len() == 0 && Default != nullptr)
+    {
+        Dest.SendInterval = Default->SendInterval;
+    }
+    else
+    {
+        Dest.SendInterval = FCString::Atoi(*SendInterval);
+    }
+    const FString MaxBufferSize = GetConfigValueFromIni(TEXT("MaxBufferSize"), false);
+    if (MaxBufferSize.Len() == 0 && Default != nullptr)
+    {
+        Dest.MaxBufferSize = Default->MaxBufferSize;
+    }
+    else
+    {
+        Dest.MaxBufferSize = FCString::Atoi(*MaxBufferSize);
+    }
+    const FString QueryTakeLimit = GetConfigValueFromIni(TEXT("QueryTakeLimit"), false);
+    if (QueryTakeLimit.Len() == 0 && Default != nullptr)
+    {
+        Dest.QueryTakeLimit = Default->QueryTakeLimit;
+    }
+    else
+    {
+        Dest.QueryTakeLimit = FCString::Atoi(*QueryTakeLimit);
+    }
+    const FString AuthenticationKey = GetConfigValueFromIni(TEXT("AuthenticationKey"), false);
+    if (AuthenticationKey.Len() == 0 && Default != nullptr)
+    {
+        Dest.AuthenticationKey = Default->AuthenticationKey;
+    }
+    else
+    {
+        Dest.AuthenticationKey = AuthenticationKey;
+    }
 }
 
 void UTelemetrySettings::WriteConfigStruct(const FString& Section, const FTelemetryConfigSetting& Source)
 {
-	SetConfigValueFromIni(TEXT("QueryUrl"), Source.QueryUrl);
-	SetConfigValueFromIni(TEXT("IngestUrl"), Source.IngestUrl);
-	SetConfigValueFromIni(TEXT("SendInterval"), FString::Printf(TEXT("%d"), Source.SendInterval));
-	SetConfigValueFromIni(TEXT("MaxBufferSize"), FString::Printf(TEXT("%d"), Source.MaxBufferSize));
-	SetConfigValueFromIni(TEXT("QueryTakeLimit"), FString::Printf(TEXT("%d"), Source.QueryTakeLimit));
-	SetConfigValueFromIni(TEXT("AuthenticationKey"), Source.AuthenticationKey);
+    SetConfigValueFromIni(TEXT("QueryUrl"), Source.QueryUrl);
+    SetConfigValueFromIni(TEXT("IngestUrl"), Source.IngestUrl);
+    SetConfigValueFromIni(TEXT("SendInterval"), FString::Printf(TEXT("%d"), Source.SendInterval));
+    SetConfigValueFromIni(TEXT("MaxBufferSize"), FString::Printf(TEXT("%d"), Source.MaxBufferSize));
+    SetConfigValueFromIni(TEXT("QueryTakeLimit"), FString::Printf(TEXT("%d"), Source.QueryTakeLimit));
+    SetConfigValueFromIni(TEXT("AuthenticationKey"), Source.AuthenticationKey);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerCommands.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerCommands.cpp
@@ -16,9 +16,9 @@
 void TelemetryVisualizerCommands::RegisterCommands()
 {
 #define LOCTEXT_NAMESPACE "TelemetryVisualizerCommands"
-	UI_COMMAND(m_displayDataTab, "Data Viewer", "Data Viewer", EUserInterfaceActionType::Check, FInputGesture());
-	UI_COMMAND(m_displayVizTab, "Visualization Tools", "Vizualization Tools", EUserInterfaceActionType::Check, FInputGesture());
-	UI_COMMAND(m_displayAll, "Open All", "Open All", EUserInterfaceActionType::Check, FInputGesture());
+    UI_COMMAND(m_displayDataTab, "Data Viewer", "Data Viewer", EUserInterfaceActionType::Check, FInputGesture());
+    UI_COMMAND(m_displayVizTab, "Visualization Tools", "Vizualization Tools", EUserInterfaceActionType::Check, FInputGesture());
+    UI_COMMAND(m_displayAll, "Open All", "Open All", EUserInterfaceActionType::Check, FInputGesture());
 #undef LOCTEXT_NAMESPACE
 }
 

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerCommands.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerCommands.h
@@ -19,15 +19,15 @@ class TelemetryVisualizerCommands : public TCommands<TelemetryVisualizerCommands
 {
 public:
 
-	TelemetryVisualizerCommands()
-		: TCommands<TelemetryVisualizerCommands>(TEXT("TelemetryVisualizer"), NSLOCTEXT("Contexts", "TelemetryVisualizer", "Telemetry Plugin"), NAME_None, FEditorStyle::GetStyleSetName())
-	{
-	}
+    TelemetryVisualizerCommands()
+        : TCommands<TelemetryVisualizerCommands>(TEXT("TelemetryVisualizer"), NSLOCTEXT("Contexts", "TelemetryVisualizer", "Telemetry Plugin"), NAME_None, FEditorStyle::GetStyleSetName())
+    {
+    }
 
-	virtual void RegisterCommands() override;
+    virtual void RegisterCommands() override;
 
-	TSharedPtr< FUICommandInfo > m_displayDataTab;
-	TSharedPtr< FUICommandInfo > m_displayVizTab;
-	TSharedPtr< FUICommandInfo > m_displayAll;
+    TSharedPtr< FUICommandInfo > m_displayDataTab;
+    TSharedPtr< FUICommandInfo > m_displayVizTab;
+    TSharedPtr< FUICommandInfo > m_displayAll;
 };
 #endif

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
@@ -18,940 +18,940 @@
 //Spawns the data tab layout
 TSharedRef<SDockTab> FTelemetryVisualizerUI::SpawnDataTab(const FSpawnTabArgs& TabSpawnArgs)
 {
-	//Handler for query returns
-	m_queryResultHandler.BindRaw(this, &FTelemetryVisualizerUI::QueryResults);
-	m_isWaiting = false;
+    //Handler for query returns
+    m_queryResultHandler.BindRaw(this, &FTelemetryVisualizerUI::QueryResults);
+    m_isWaiting = false;
 
-	TSharedRef<SDockTab> retTab = SNew(SDockTab)
-		.Label(LOCTEXT("Data_Viewer", "Data Viewer"))
-		.TabRole(ETabRole::NomadTab)
-		[
-			SNew(SVerticalBox)
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10.f, 5.f, 0.f, 0.f)
-			[
-				SNew(STextBlock)
-					.Text(FText::FromString("Event Settings"))
-			]
-			+ SVerticalBox::Slot()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10)
-			[
-				SNew(SBorder)
-					.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
-					.Content()
-				[
-					SNew(SVerticalBox)
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10.f, 5.f, 0.f, 5.f)
-					[
-						SNew(STextBlock)
-							.Text(FText::FromString("Create clauses to define what events are retrieved from the server. The local results are filtered in the search area"))
-					]
-					+ SVerticalBox::Slot()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10)
-					[
-						//Query controls are generated externally
-						SAssignNew(m_queryScrollBox, SScrollBox)
-							.Orientation(Orient_Vertical)
-							.ScrollBarAlwaysVisible(true)
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.HAlign(HAlign_Center)
-								.VAlign(VAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, -1)
-								.Text(LOCTEXT("Add_New_Clause", "Add New Clause"))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.HAlign(HAlign_Center)
-								.VAlign(VAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::SubmitQuery)
-								.Text_Raw(this, &FTelemetryVisualizerUI::GetButtonString)
-						]
-					]
-				]
-			]
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10.f, 5.f, 0.f, 0.f)
-			[
-				SNew(STextBlock)
-					.Text(FText::FromString("Event Search"))
-			]
-			+ SVerticalBox::Slot()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10)
-			[
-				SNew(SBorder)
-					.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
-					.Content()
-				[
-					SNew(SVerticalBox)
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Top)
-						.Padding(10)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.HAlign(HAlign_Fill)
-							.VAlign(VAlign_Center)
-						[
-							SAssignNew(m_searchText, SEditableTextBox)
-								.Text(LOCTEXT("Search_Terms", ""))
-						]
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-						[
-							SNew(SButton)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::UpdateFilterEvents)
-								.ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
-							[
-								SNew(SBox)
-									.WidthOverride(MultiBoxConstants::MenuIconSize)
-									.HeightOverride(MultiBoxConstants::MenuIconSize)
-								[
-									SNew(SImage)
-										.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "Symbols.SearchGlass").GetIcon())
-								]
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10, 0, 0, 0)
-					[
-						SAssignNew(m_messageText, STextBlock)
-					]
-					+ SVerticalBox::Slot()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10)
-					[
-						//Event filters are generated externally
-						SAssignNew(m_scrollBox, SScrollBox)
-							.Orientation(Orient_Vertical)
-							.ScrollBarAlwaysVisible(true)
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(10)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.Text(LOCTEXT("Select_All", "Select All"))
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::SelectAll)
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.Text(LOCTEXT("Select_None", "Select None"))
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::SelectNone)
-						]
-					]
-				]
-			]
-		];
+    TSharedRef<SDockTab> retTab = SNew(SDockTab)
+        .Label(LOCTEXT("Data_Viewer", "Data Viewer"))
+        .TabRole(ETabRole::NomadTab)
+        [
+            SNew(SVerticalBox)
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10.f, 5.f, 0.f, 0.f)
+            [
+                SNew(STextBlock)
+                    .Text(FText::FromString("Event Settings"))
+            ]
+            + SVerticalBox::Slot()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10)
+            [
+                SNew(SBorder)
+                    .BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+                    .Content()
+                [
+                    SNew(SVerticalBox)
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10.f, 5.f, 0.f, 5.f)
+                    [
+                        SNew(STextBlock)
+                            .Text(FText::FromString("Create clauses to define what events are retrieved from the server. The local results are filtered in the search area"))
+                    ]
+                    + SVerticalBox::Slot()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10)
+                    [
+                        //Query controls are generated externally
+                        SAssignNew(m_queryScrollBox, SScrollBox)
+                            .Orientation(Orient_Vertical)
+                            .ScrollBarAlwaysVisible(true)
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .HAlign(HAlign_Center)
+                                .VAlign(VAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, -1)
+                                .Text(LOCTEXT("Add_New_Clause", "Add New Clause"))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .HAlign(HAlign_Center)
+                                .VAlign(VAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::SubmitQuery)
+                                .Text_Raw(this, &FTelemetryVisualizerUI::GetButtonString)
+                        ]
+                    ]
+                ]
+            ]
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10.f, 5.f, 0.f, 0.f)
+            [
+                SNew(STextBlock)
+                    .Text(FText::FromString("Event Search"))
+            ]
+            + SVerticalBox::Slot()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10)
+            [
+                SNew(SBorder)
+                    .BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+                    .Content()
+                [
+                    SNew(SVerticalBox)
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Top)
+                        .Padding(10)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .HAlign(HAlign_Fill)
+                            .VAlign(VAlign_Center)
+                        [
+                            SAssignNew(m_searchText, SEditableTextBox)
+                                .Text(LOCTEXT("Search_Terms", ""))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                        [
+                            SNew(SButton)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::UpdateFilterEvents)
+                                .ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
+                            [
+                                SNew(SBox)
+                                    .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                    .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                [
+                                    SNew(SImage)
+                                        .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "Symbols.SearchGlass").GetIcon())
+                                ]
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10, 0, 0, 0)
+                    [
+                        SAssignNew(m_messageText, STextBlock)
+                    ]
+                    + SVerticalBox::Slot()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10)
+                    [
+                        //Event filters are generated externally
+                        SAssignNew(m_scrollBox, SScrollBox)
+                            .Orientation(Orient_Vertical)
+                            .ScrollBarAlwaysVisible(true)
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(10)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .Text(LOCTEXT("Select_All", "Select All"))
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::SelectAll)
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .Text(LOCTEXT("Select_None", "Select None"))
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::SelectNone)
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
-	GenerateQueryScrollBox();
+    GenerateQueryScrollBox();
 
-	return retTab;
+    return retTab;
 }
 
 /////////////////////////////////QUERY SCROLLBOX/////////////////////////////////
 //Generates the list query conditions
 void FTelemetryVisualizerUI::GenerateQueryScrollBox()
 {
-	if (!m_queryScrollBox.IsValid())
-	{
-		return;
-	}
-	m_queryScrollBox->ClearChildren();
+    if (!m_queryScrollBox.IsValid())
+    {
+        return;
+    }
+    m_queryScrollBox->ClearChildren();
 
-	m_queryScrollBox->AddSlot()
-		.HAlign(HAlign_Fill)
-		.VAlign(VAlign_Fill)
-	[
-		SNew(SHorizontalBox)
-		+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.Padding(2.f, 0.f, 0.f, 0.f)
-			.VAlign(VAlign_Center)
-		[
-			// +
-			SNew(SButton)
-				.OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, 0)
-				.ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
-			[
-				SNew(SBox)
-					.WidthOverride(MultiBoxConstants::MenuIconSize)
-					.HeightOverride(MultiBoxConstants::MenuIconSize)
-				[
-					SNew(SImage)
-						.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "WorldBrowser.AddLayer").GetIcon())
-				]
-			]
-		]
-		+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.Padding(54.f, 0.f, 0.f, 0.f)
-			.VAlign(VAlign_Center)
-		[
-			//FIELD
-			SNew(SBox)
-				.WidthOverride(90)
-			[
-				SNew(SComboBox<TSharedPtr<FString>>)
-					.OptionsSource(&m_queryFieldList)
-					.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnFieldSelectionChanged, 0)
-					.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-					.InitiallySelectedItem(m_queryFieldList[m_queryCollection[0].Field])
-				[
-					SNew(STextBlock)
-						.Text_Raw(this, &FTelemetryVisualizerUI::GetFieldItem, 0)
-				]
-			]
-		]
-		+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.Padding(2.f, 0.f, 0.f, 0.f)
-			.VAlign(VAlign_Center)
-		[
-			//OPERATOR
-			SNew(SBox)
-				.WidthOverride(40)
-			[
-				SNew(SComboBox<TSharedPtr<FString>>)
-					.OptionsSource(&m_queryOperatorList)
-					.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnOperatorSelectionChanged, 0)
-					.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-					.InitiallySelectedItem(m_queryOperatorList[m_queryCollection[0].Operator])
-				[
-					SNew(STextBlock)
-						.Text_Raw(this, &FTelemetryVisualizerUI::GetOperatorItem, 0)
-				]
-			]
-		]
-		+ SHorizontalBox::Slot()
-			.HAlign(HAlign_Fill)
-			.Padding(2.f, 0.f, 26.f, 0.f)
-			.VAlign(VAlign_Center)
-		[
-			//VALUE
-			SAssignNew(m_valueText[0], SEditableTextBox)
-				.OnTextChanged_Raw(this, &FTelemetryVisualizerUI::UpdateClauseValue, 0)
-				.Text(FText::FromString(m_queryCollection[0].Value))
-		]
-	];
+    m_queryScrollBox->AddSlot()
+        .HAlign(HAlign_Fill)
+        .VAlign(VAlign_Fill)
+    [
+        SNew(SHorizontalBox)
+        + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(2.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+        [
+            // +
+            SNew(SButton)
+                .OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, 0)
+                .ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
+            [
+                SNew(SBox)
+                    .WidthOverride(MultiBoxConstants::MenuIconSize)
+                    .HeightOverride(MultiBoxConstants::MenuIconSize)
+                [
+                    SNew(SImage)
+                        .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "WorldBrowser.AddLayer").GetIcon())
+                ]
+            ]
+        ]
+        + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(54.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+        [
+            //FIELD
+            SNew(SBox)
+                .WidthOverride(90)
+            [
+                SNew(SComboBox<TSharedPtr<FString>>)
+                    .OptionsSource(&m_queryFieldList)
+                    .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnFieldSelectionChanged, 0)
+                    .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                    .InitiallySelectedItem(m_queryFieldList[m_queryCollection[0].Field])
+                [
+                    SNew(STextBlock)
+                        .Text_Raw(this, &FTelemetryVisualizerUI::GetFieldItem, 0)
+                ]
+            ]
+        ]
+        + SHorizontalBox::Slot()
+            .AutoWidth()
+            .Padding(2.f, 0.f, 0.f, 0.f)
+            .VAlign(VAlign_Center)
+        [
+            //OPERATOR
+            SNew(SBox)
+                .WidthOverride(40)
+            [
+                SNew(SComboBox<TSharedPtr<FString>>)
+                    .OptionsSource(&m_queryOperatorList)
+                    .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnOperatorSelectionChanged, 0)
+                    .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                    .InitiallySelectedItem(m_queryOperatorList[m_queryCollection[0].Operator])
+                [
+                    SNew(STextBlock)
+                        .Text_Raw(this, &FTelemetryVisualizerUI::GetOperatorItem, 0)
+                ]
+            ]
+        ]
+        + SHorizontalBox::Slot()
+            .HAlign(HAlign_Fill)
+            .Padding(2.f, 0.f, 26.f, 0.f)
+            .VAlign(VAlign_Center)
+        [
+            //VALUE
+            SAssignNew(m_valueText[0], SEditableTextBox)
+                .OnTextChanged_Raw(this, &FTelemetryVisualizerUI::UpdateClauseValue, 0)
+                .Text(FText::FromString(m_queryCollection[0].Value))
+        ]
+    ];
 
-	for (int i = 1; i < m_queryCollection.Num(); i++)
-	{
-		m_queryScrollBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-		[
-			SNew(SHorizontalBox)
-			+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				// +
-				SNew(SButton)
-					.OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, i)
-					.ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
-				[
-					SNew(SBox)
-						.WidthOverride(MultiBoxConstants::MenuIconSize)
-						.HeightOverride(MultiBoxConstants::MenuIconSize)
-					[
-						SNew(SImage)
-							.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "WorldBrowser.AddLayer").GetIcon())
-					]
-				]
-			]
-			+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				//AND / OR
-				SNew(SBox)
-					.WidthOverride(50)
-				[
-					SNew(SComboBox<TSharedPtr<FString>>)
-						.OptionsSource(&m_queryAndOrList)
-						.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnAndOrSelectionChanged, i)
-						.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-						.InitiallySelectedItem(m_queryAndOrList[m_queryCollection[i].isAnd])
-					[
-						SNew(STextBlock)
-							.Text_Raw(this, &FTelemetryVisualizerUI::GetAndOrItem, i)
-					]
-				]
-			]
-			+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				//FIELD
-				SNew(SBox)
-					.WidthOverride(90)
-				[
-					SNew(SComboBox<TSharedPtr<FString>>)
-						.OptionsSource(&m_queryFieldList)
-						.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnFieldSelectionChanged, i)
-						.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-						.InitiallySelectedItem(m_queryFieldList[m_queryCollection[i].Field])
-					[
-						SNew(STextBlock)
-							.Text_Raw(this, &FTelemetryVisualizerUI::GetFieldItem, i)
-					]
-				]
-			]
-			+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				//OPERATOR
-				SNew(SBox)
-					.WidthOverride(40)
-				[
-					SNew(SComboBox<TSharedPtr<FString>>)
-						.OptionsSource(&m_queryOperatorList)
-						.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnOperatorSelectionChanged, i)
-						.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-						.InitiallySelectedItem(m_queryOperatorList[m_queryCollection[i].Operator])
-					[
-						SNew(STextBlock)
-							.Text_Raw(this, &FTelemetryVisualizerUI::GetOperatorItem, i)
-					]
-				]
-			]
-			+ SHorizontalBox::Slot()
-				.HAlign(HAlign_Fill)
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				//VALUE
-				SAssignNew(m_valueText[i], SEditableTextBox)
-					.OnTextChanged_Raw(this, &FTelemetryVisualizerUI::UpdateClauseValue, i)
-					.Text(FText::FromString(m_queryCollection[i].Value))
-			]
-			+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.Padding(2.f, 0.f, 0.f, 0.f)
-				.VAlign(VAlign_Center)
-			[
-				// X
-				SNew(SButton)
-					.OnClicked_Raw(this, &FTelemetryVisualizerUI::RemoveClause, i)
-					.ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
-				[
-					SNew(SBox)
-						.WidthOverride(MultiBoxConstants::MenuIconSize)
-						.HeightOverride(MultiBoxConstants::MenuIconSize)
-					[
-						SNew(SImage)
-							.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "Symbols.X").GetIcon())
-					]
-				]
-			]
-		];
-	}
+    for (int i = 1; i < m_queryCollection.Num(); i++)
+    {
+        m_queryScrollBox->AddSlot()
+            .HAlign(HAlign_Fill)
+            .VAlign(VAlign_Fill)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                // +
+                SNew(SButton)
+                    .OnClicked_Raw(this, &FTelemetryVisualizerUI::AddClause, i)
+                    .ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
+                [
+                    SNew(SBox)
+                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                    [
+                        SNew(SImage)
+                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "WorldBrowser.AddLayer").GetIcon())
+                    ]
+                ]
+            ]
+            + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                //AND / OR
+                SNew(SBox)
+                    .WidthOverride(50)
+                [
+                    SNew(SComboBox<TSharedPtr<FString>>)
+                        .OptionsSource(&m_queryAndOrList)
+                        .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnAndOrSelectionChanged, i)
+                        .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                        .InitiallySelectedItem(m_queryAndOrList[m_queryCollection[i].isAnd])
+                    [
+                        SNew(STextBlock)
+                            .Text_Raw(this, &FTelemetryVisualizerUI::GetAndOrItem, i)
+                    ]
+                ]
+            ]
+            + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                //FIELD
+                SNew(SBox)
+                    .WidthOverride(90)
+                [
+                    SNew(SComboBox<TSharedPtr<FString>>)
+                        .OptionsSource(&m_queryFieldList)
+                        .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnFieldSelectionChanged, i)
+                        .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                        .InitiallySelectedItem(m_queryFieldList[m_queryCollection[i].Field])
+                    [
+                        SNew(STextBlock)
+                            .Text_Raw(this, &FTelemetryVisualizerUI::GetFieldItem, i)
+                    ]
+                ]
+            ]
+            + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                //OPERATOR
+                SNew(SBox)
+                    .WidthOverride(40)
+                [
+                    SNew(SComboBox<TSharedPtr<FString>>)
+                        .OptionsSource(&m_queryOperatorList)
+                        .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnOperatorSelectionChanged, i)
+                        .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                        .InitiallySelectedItem(m_queryOperatorList[m_queryCollection[i].Operator])
+                    [
+                        SNew(STextBlock)
+                            .Text_Raw(this, &FTelemetryVisualizerUI::GetOperatorItem, i)
+                    ]
+                ]
+            ]
+            + SHorizontalBox::Slot()
+                .HAlign(HAlign_Fill)
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                //VALUE
+                SAssignNew(m_valueText[i], SEditableTextBox)
+                    .OnTextChanged_Raw(this, &FTelemetryVisualizerUI::UpdateClauseValue, i)
+                    .Text(FText::FromString(m_queryCollection[i].Value))
+            ]
+            + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(2.f, 0.f, 0.f, 0.f)
+                .VAlign(VAlign_Center)
+            [
+                // X
+                SNew(SButton)
+                    .OnClicked_Raw(this, &FTelemetryVisualizerUI::RemoveClause, i)
+                    .ButtonStyle(FEditorStyle::Get(), "HoverHintOnly")
+                [
+                    SNew(SBox)
+                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                    [
+                        SNew(SImage)
+                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "Symbols.X").GetIcon())
+                    ]
+                ]
+            ]
+        ];
+    }
 }
 
 FReply FTelemetryVisualizerUI::AddClause(int index)
 {
-	if (index == -1)
-	{
-		m_queryCollection.Add(SQuerySetting());
-		m_valueText.SetNum(m_valueText.Num() + 1);
-	}
-	else
-	{
-		m_queryCollection.Insert(SQuerySetting(), index);
-		m_valueText.InsertDefaulted(index, 1);
-	}
+    if (index == -1)
+    {
+        m_queryCollection.Add(SQuerySetting());
+        m_valueText.SetNum(m_valueText.Num() + 1);
+    }
+    else
+    {
+        m_queryCollection.Insert(SQuerySetting(), index);
+        m_valueText.InsertDefaulted(index, 1);
+    }
 
-	GenerateQueryScrollBox();
+    GenerateQueryScrollBox();
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 FReply FTelemetryVisualizerUI::RemoveClause(int index)
 {
-	m_queryCollection.RemoveAt(index);
-	m_valueText.RemoveAt(index);
-	GenerateQueryScrollBox();
+    m_queryCollection.RemoveAt(index);
+    m_valueText.RemoveAt(index);
+    GenerateQueryScrollBox();
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 FText FTelemetryVisualizerUI::GetButtonString() const
 {
-	if (m_isWaiting)
-	{
-		return LOCTEXT("Running...", "Running...");
-	}
-	return LOCTEXT("Submit", "Submit");
+    if (m_isWaiting)
+    {
+        return LOCTEXT("Running...", "Running...");
+    }
+    return LOCTEXT("Submit", "Submit");
 }
 
 //Translates query UI in to query nodes for execution
 FReply FTelemetryVisualizerUI::SubmitQuery()
 {
-	FQueryNodeList andNodes;
-	FQueryNodeList orNodes;
+    FQueryNodeList andNodes;
+    FQueryNodeList orNodes;
 
-	m_queryCollection[0].isAnd = true;
+    m_queryCollection[0].isAnd = true;
 
-	for (int i = 0; i < m_queryCollection.Num(); i++)
-	{
-		EQueryOp op = EQueryOp::Eq;
-		switch (m_queryCollection[i].Operator)
-		{
-		case QueryOperator::Not_Equal:
-			op = EQueryOp::Neq;
-			break;
-		case QueryOperator::GreaterThan:
-			op = EQueryOp::Gt;
-			break;
-		case QueryOperator::LessThan:
-			op = EQueryOp::Lt;
-			break;
-		case QueryOperator::GreaterThanOrEqual:
-			op = EQueryOp::Gte;
-			break;
-		case QueryOperator::LessThanOrEqual:
-			op = EQueryOp::Lte;
-			break;
-		}
+    for (int i = 0; i < m_queryCollection.Num(); i++)
+    {
+        EQueryOp op = EQueryOp::Eq;
+        switch (m_queryCollection[i].Operator)
+        {
+        case QueryOperator::Not_Equal:
+            op = EQueryOp::Neq;
+            break;
+        case QueryOperator::GreaterThan:
+            op = EQueryOp::Gt;
+            break;
+        case QueryOperator::LessThan:
+            op = EQueryOp::Lt;
+            break;
+        case QueryOperator::GreaterThanOrEqual:
+            op = EQueryOp::Gte;
+            break;
+        case QueryOperator::LessThanOrEqual:
+            op = EQueryOp::Lte;
+            break;
+        }
 
-		if (m_queryCollection[i].isAnd)
-		{
-			andNodes.Emplace(new FQueryNode(EQueryNodeType::Comparison, QueryExpectedStrings[m_queryCollection[i].Field], op, FJsonValueUtil::Create(m_queryCollection[i].Value)));
-		}
-		else
-		{
-			orNodes.Emplace(new FQueryNode(EQueryNodeType::Comparison, QueryExpectedStrings[m_queryCollection[i].Field], op, FJsonValueUtil::Create(m_queryCollection[i].Value)));
-		}
-	}
+        if (m_queryCollection[i].isAnd)
+        {
+            andNodes.Emplace(new FQueryNode(EQueryNodeType::Comparison, QueryExpectedStrings[m_queryCollection[i].Field], op, FJsonValueUtil::Create(m_queryCollection[i].Value)));
+        }
+        else
+        {
+            orNodes.Emplace(new FQueryNode(EQueryNodeType::Comparison, QueryExpectedStrings[m_queryCollection[i].Field], op, FJsonValueUtil::Create(m_queryCollection[i].Value)));
+        }
+    }
 
-	if (m_queryCollection.Num() == 1)
-	{
-		CollectEvents(andNodes[0]);
-	}
-	else
-	{
-		if (orNodes.Num() == 1)
-		{
-			andNodes.Emplace(orNodes[0]);
-			CollectEvents(MakeShareable(new FQueryNode(EQueryNodeType::Group, EQueryOp::Or, MoveTemp(andNodes))));
-		}
-		else
-		{
-			if (orNodes.Num() > 1)
-			{
-				andNodes.Emplace(new FQueryNode(EQueryNodeType::Group, EQueryOp::Or, MoveTemp(orNodes)));
-			}
+    if (m_queryCollection.Num() == 1)
+    {
+        CollectEvents(andNodes[0]);
+    }
+    else
+    {
+        if (orNodes.Num() == 1)
+        {
+            andNodes.Emplace(orNodes[0]);
+            CollectEvents(MakeShareable(new FQueryNode(EQueryNodeType::Group, EQueryOp::Or, MoveTemp(andNodes))));
+        }
+        else
+        {
+            if (orNodes.Num() > 1)
+            {
+                andNodes.Emplace(new FQueryNode(EQueryNodeType::Group, EQueryOp::Or, MoveTemp(orNodes)));
+            }
 
-			CollectEvents(MakeShareable(new FQueryNode(EQueryNodeType::Group, EQueryOp::And, MoveTemp(andNodes))));
-		}
-	}
+            CollectEvents(MakeShareable(new FQueryNode(EQueryNodeType::Group, EQueryOp::And, MoveTemp(andNodes))));
+        }
+    }
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 FText FTelemetryVisualizerUI::GetAndOrItem(int index) const
 {
-	FString typeString = "Or";
+    FString typeString = "Or";
 
-	if (m_queryCollection[index].isAnd)
-	{
-		typeString = "And";
-	}
+    if (m_queryCollection[index].isAnd)
+    {
+        typeString = "And";
+    }
 
-	return FText::FromString(*typeString);
+    return FText::FromString(*typeString);
 }
 
 void FTelemetryVisualizerUI::OnAndOrSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index)
 {
-	if (NewValue.IsValid())
-	{
-		bool isAnd = false;
+    if (NewValue.IsValid())
+    {
+        bool isAnd = false;
 
-		if (*NewValue == "And")
-		{
-			isAnd = true;
-		}
+        if (*NewValue == "And")
+        {
+            isAnd = true;
+        }
 
-		if (m_queryCollection[index].isAnd != isAnd)
-		{
-			m_queryCollection[index].isAnd = isAnd;
-		}
-	}
+        if (m_queryCollection[index].isAnd != isAnd)
+        {
+            m_queryCollection[index].isAnd = isAnd;
+        }
+    }
 }
 
 FText FTelemetryVisualizerUI::GetFieldItem(int index) const
 {
-	return FText::FromString(*QueryFieldStrings[m_queryCollection[index].Field]);
-	return FText::FromString(*QueryOperatorStrings[m_queryCollection[index].Operator]);
+    return FText::FromString(*QueryFieldStrings[m_queryCollection[index].Field]);
+    return FText::FromString(*QueryOperatorStrings[m_queryCollection[index].Operator]);
 }
 
 void FTelemetryVisualizerUI::OnFieldSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index)
 {
-	if (NewValue.IsValid())
-	{
-		QueryField newType = QueryField::Category;
+    if (NewValue.IsValid())
+    {
+        QueryField newType = QueryField::Category;
 
-		for (int i = 1; i < QueryFieldStrings.Num(); i++)
-		{
-			if (*NewValue == QueryFieldStrings[i])
-			{
-				newType = (QueryField)i;
-			}
-		}
+        for (int i = 1; i < QueryFieldStrings.Num(); i++)
+        {
+            if (*NewValue == QueryFieldStrings[i])
+            {
+                newType = (QueryField)i;
+            }
+        }
 
-		if (m_queryCollection[index].Field != newType)
-		{
-			m_queryCollection[index].Field = newType;
-		}
-	}
+        if (m_queryCollection[index].Field != newType)
+        {
+            m_queryCollection[index].Field = newType;
+        }
+    }
 }
 
 FText FTelemetryVisualizerUI::GetOperatorItem(int index) const
 {
-	return FText::FromString(*QueryOperatorStrings[m_queryCollection[index].Operator]);
+    return FText::FromString(*QueryOperatorStrings[m_queryCollection[index].Operator]);
 }
 
 void FTelemetryVisualizerUI::OnOperatorSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index)
 {
-	if (NewValue.IsValid())
-	{
-		QueryOperator newType = QueryOperator::Equal;
+    if (NewValue.IsValid())
+    {
+        QueryOperator newType = QueryOperator::Equal;
 
-		for (int i = 1; i < QueryOperatorStrings.Num(); i++)
-		{
-			if (*NewValue == QueryOperatorStrings[i])
-			{
-				newType = (QueryOperator)i;
-			}
-		}
+        for (int i = 1; i < QueryOperatorStrings.Num(); i++)
+        {
+            if (*NewValue == QueryOperatorStrings[i])
+            {
+                newType = (QueryOperator)i;
+            }
+        }
 
-		if (m_queryCollection[index].Operator != newType)
-		{
-			m_queryCollection[index].Operator = newType;
-		}
-	}
+        if (m_queryCollection[index].Operator != newType)
+        {
+            m_queryCollection[index].Operator = newType;
+        }
+    }
 }
 
 void FTelemetryVisualizerUI::UpdateClauseValue(const FText& text, int index)
 {
-	m_queryCollection[index].Value = text.ToString();
-	return;
+    m_queryCollection[index].Value = text.ToString();
+    return;
 }
 
 //Call to execute query
 void FTelemetryVisualizerUI::CollectEvents(FQueryNodePtr query)
 {
-	if (!m_isWaiting)
-	{
-		m_isWaiting = true;
-		AsyncTask(ENamedThreads::GameThread, [this, query]()
-		{
-			m_queryExecuter.ExecuteCustomQuery(m_querySerializer.Serialize(query), m_queryResultHandler);
-		});
-	}
+    if (!m_isWaiting)
+    {
+        m_isWaiting = true;
+        AsyncTask(ENamedThreads::GameThread, [this, query]()
+        {
+            m_queryExecuter.ExecuteCustomQuery(m_querySerializer.Serialize(query), m_queryResultHandler);
+        });
+    }
 }
 
 //Called when the query request completes.  Converts results to a local collection
 void FTelemetryVisualizerUI::QueryResults(TSharedPtr<SQueryResult> results)
 {
-	m_queryEventCollection.Empty();
+    m_queryEventCollection.Empty();
 
-	FString currentName;
+    FString currentName;
 
-	for (auto newEvent : results->Events)
-	{
-		int currentIdx = -1;
-		currentName = newEvent.GetName();
+    for (auto newEvent : results->Events)
+    {
+        int currentIdx = -1;
+        currentName = newEvent.GetName();
 
-		for (int i = 0; i < m_queryEventCollection.Num(); i++)
-		{
-			if (m_queryEventCollection[i].name == currentName)
-			{
-				currentIdx = i;
-				break;
-			}
-		}
+        for (int i = 0; i < m_queryEventCollection.Num(); i++)
+        {
+            if (m_queryEventCollection[i].eventname == currentName)
+            {
+                currentIdx = i;
+                break;
+            }
+        }
 
-		if (currentIdx == -1)
-		{
-			currentIdx = m_queryEventCollection.Emplace(SEventEditorContainer(currentName, m_queryEventCollection.Num()));
-		}
+        if (currentIdx == -1)
+        {
+            currentIdx = m_queryEventCollection.Emplace(SEventEditorContainer(currentName, m_queryEventCollection.Num()));
+        }
 
-		m_queryEventCollection[currentIdx].AddEvent(newEvent);
-	}
+        m_queryEventCollection[currentIdx].AddEvent(newEvent);
+    }
 
-	int count = FilterEvents();
-	GenerateScrollBoxes(count);
-	m_isWaiting = false;
+    int count = FilterEvents();
+    GenerateScrollBoxes(count);
+    m_isWaiting = false;
 }
 
 /////////////////////////////////EVENT COLLECTION/////////////////////////////////
 //Generates the list of available and filtered events for the tab
 void FTelemetryVisualizerUI::GenerateScrollBox()
 {
-	if (!m_scrollBox.IsValid())
-	{
-		return;
-	}
-	m_scrollBox->ClearChildren();
+    if (!m_scrollBox.IsValid())
+    {
+        return;
+    }
+    m_scrollBox->ClearChildren();
 
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		m_scrollBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-			[
-				SNew(SHorizontalBox)
-				+ SHorizontalBox::Slot()
-					.HAlign(HAlign_Fill)
-					.VAlign(VAlign_Center)
-				[
-					SNew(SCheckBox)
-						.IsChecked_Lambda([this, i]() -> ECheckBoxState
-						{
-							if (m_filterCollection[i]->ShouldDraw()) return ECheckBoxState::Checked;
-							return ECheckBoxState::Unchecked;
-						})
-						.OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnEventChecked, FText::FromString(m_filterCollection[i]->name))
-					[
-						SNew(STextBlock)
-							.Text(FText::FromString(m_filterCollection[i]->name))
-					]
-				]
-				+ SHorizontalBox::Slot()
-					.AutoWidth()
-					.HAlign(HAlign_Right)
-					.VAlign(VAlign_Center)
-				[
-					SNew(SComboBox<TSharedPtr<FString>>)
-						.OptionsSource(&m_shapeList)
-						.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnTypeSelectionChanged, i)
-						.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-						.InitiallySelectedItem(m_shapeList[0])
-					[
-						SNew(STextBlock)
-							.Text_Raw(this, &FTelemetryVisualizerUI::GetTypeItem, i)
-					]
-				]
-				+ SHorizontalBox::Slot()
-					.AutoWidth()
-					.HAlign(HAlign_Right)
-					.VAlign(VAlign_Center)
-				[
-					SNew(SButton)
-						.OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString(m_filterCollection[i]->name), false)
-					[
-						SNew(SBorder)
-							.Padding(FMargin(6))
-							.BorderBackgroundColor(FSlateColor(m_filterCollection[i]->GetColor()))
-							.BorderImage(m_filterCollection[i]->GetBrush())
-					]
-				]
-			];
-	}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        m_scrollBox->AddSlot()
+            .HAlign(HAlign_Fill)
+            .VAlign(VAlign_Fill)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot()
+                    .HAlign(HAlign_Fill)
+                    .VAlign(VAlign_Center)
+                [
+                    SNew(SCheckBox)
+                        .IsChecked_Lambda([this, i]() -> ECheckBoxState
+                        {
+                            if (m_filterCollection[i]->ShouldDraw()) return ECheckBoxState::Checked;
+                            return ECheckBoxState::Unchecked;
+                        })
+                        .OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnEventChecked, FText::FromString(m_filterCollection[i]->eventname))
+                    [
+                        SNew(STextBlock)
+                            .Text(FText::FromString(m_filterCollection[i]->eventname))
+                    ]
+                ]
+                + SHorizontalBox::Slot()
+                    .AutoWidth()
+                    .HAlign(HAlign_Right)
+                    .VAlign(VAlign_Center)
+                [
+                    SNew(SComboBox<TSharedPtr<FString>>)
+                        .OptionsSource(&m_shapeList)
+                        .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnTypeSelectionChanged, i)
+                        .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                        .InitiallySelectedItem(m_shapeList[0])
+                    [
+                        SNew(STextBlock)
+                            .Text_Raw(this, &FTelemetryVisualizerUI::GetTypeItem, i)
+                    ]
+                ]
+                + SHorizontalBox::Slot()
+                    .AutoWidth()
+                    .HAlign(HAlign_Right)
+                    .VAlign(VAlign_Center)
+                [
+                    SNew(SButton)
+                        .OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString(m_filterCollection[i]->eventname), false)
+                    [
+                        SNew(SBorder)
+                            .Padding(FMargin(6))
+                            .BorderBackgroundColor(FSlateColor(m_filterCollection[i]->GetColor()))
+                            .BorderImage(m_filterCollection[i]->GetBrush())
+                    ]
+                ]
+            ];
+    }
 }
 
 FReply FTelemetryVisualizerUI::UpdateFilterEvents()
 {
-	int count = FilterEvents();
-	GenerateScrollBoxes(count);
+    int count = FilterEvents();
+    GenerateScrollBoxes(count);
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 int FTelemetryVisualizerUI::FilterEvents()
 {
-	int count = 0;
-	FString searchText = m_searchText.IsValid() ? m_searchText->GetText().ToString() : "";
-	m_filterCollection.Empty();
+    int count = 0;
+    FString searchText = m_searchText.IsValid() ? m_searchText->GetText().ToString() : "";
+    m_filterCollection.Empty();
 
-	if (searchText == "")
-	{
-		for (int i = 0; i < m_queryEventCollection.Num(); i++)
-		{
-			m_filterCollection.Emplace(&m_queryEventCollection[i]);
-			count += m_queryEventCollection[i].events.Num();
-		}
-	}
-	else
-	{
-		for (int i = 0; i < m_queryEventCollection.Num(); i++)
-		{
-			if (m_queryEventCollection[i].name.Contains(searchText))
-			{
-				m_filterCollection.Emplace(&m_queryEventCollection[i]);
-				count += m_queryEventCollection[i].events.Num();
-			}
-		}
-	}
+    if (searchText == "")
+    {
+        for (int i = 0; i < m_queryEventCollection.Num(); i++)
+        {
+            m_filterCollection.Emplace(&m_queryEventCollection[i]);
+            count += m_queryEventCollection[i].events.Num();
+        }
+    }
+    else
+    {
+        for (int i = 0; i < m_queryEventCollection.Num(); i++)
+        {
+            if (m_queryEventCollection[i].eventname.Contains(searchText))
+            {
+                m_filterCollection.Emplace(&m_queryEventCollection[i]);
+                count += m_queryEventCollection[i].events.Num();
+            }
+        }
+    }
 
-	return count;
+    return count;
 }
 
 void FTelemetryVisualizerUI::GenerateScrollBoxes(int count)
 {
-	GenerateScrollBox();
-	GenerateEventBox();
-	m_needsActorUpdate = true;
+    GenerateScrollBox();
+    GenerateEventBox();
+    m_needsActorUpdate = true;
 
-	if (m_messageText.IsValid())
-	{
-		m_messageText->SetText(FText::Format(LOCTEXT("Event_Count", "Found {0} events"), FText::AsNumber(count)));
-	}
+    if (m_messageText.IsValid())
+    {
+        m_messageText->SetText(FText::Format(LOCTEXT("Event_Count", "Found {0} events"), FText::AsNumber(count)));
+    }
 }
 
 /////////////////////////////////EVENT FILTER SCROLLBOX/////////////////////////////////
 void FTelemetryVisualizerUI::OnEventChecked(ECheckBoxState NewState, FText eventName)
 {
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		if (m_filterCollection[i]->name == eventName.ToString())
-		{
-			if (NewState == ECheckBoxState::Checked)
-			{
-				m_filterCollection[i]->SetShouldDraw(true);
-			}
-			else
-			{
-				m_filterCollection[i]->SetShouldDraw(false);
-			}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        if (m_filterCollection[i]->eventname == eventName.ToString())
+        {
+            if (NewState == ECheckBoxState::Checked)
+            {
+                m_filterCollection[i]->SetShouldDraw(true);
+            }
+            else
+            {
+                m_filterCollection[i]->SetShouldDraw(false);
+            }
 
-			m_needsActorUpdate = true;
-			break;
-		}
-	}
+            m_needsActorUpdate = true;
+            break;
+        }
+    }
 }
 
 FReply FTelemetryVisualizerUI::DisplayDrawColor(FText eventName, bool isHeatmap)
 {
-	FColorPickerArgs PickerArgs;
-	PickerArgs.DisplayGamma = TAttribute<float>::Create(TAttribute<float>::FGetter::CreateUObject(GEngine, &UEngine::GetDisplayGamma));
+    FColorPickerArgs PickerArgs;
+    PickerArgs.DisplayGamma = TAttribute<float>::Create(TAttribute<float>::FGetter::CreateUObject(GEngine, &UEngine::GetDisplayGamma));
 
-	if (isHeatmap)
-	{
-		PickerArgs.bUseAlpha = true;
-		PickerArgs.OnColorCommitted = FOnLinearColorValueChanged::CreateRaw(this, &FTelemetryVisualizerUI::SelectHeatmapDrawColor);
+    if (isHeatmap)
+    {
+        PickerArgs.bUseAlpha = true;
+        PickerArgs.OnColorCommitted = FOnLinearColorValueChanged::CreateRaw(this, &FTelemetryVisualizerUI::SelectHeatmapDrawColor);
 
-		if (eventName.ToString() == "High")
-		{
-			PickerArgs.InitialColorOverride = FLinearColor(m_heatmapColor.GetHighColor());
-		}
-		else
-		{
-			PickerArgs.InitialColorOverride = FLinearColor(m_heatmapColor.GetLowColor());
-		}
-	}
-	else
-	{
-		PickerArgs.bUseAlpha = false;
-		PickerArgs.OnColorCommitted = FOnLinearColorValueChanged::CreateRaw(this, &FTelemetryVisualizerUI::SelectDrawColor);
+        if (eventName.ToString() == "High")
+        {
+            PickerArgs.InitialColorOverride = FLinearColor(m_heatmapColor.GetHighColor());
+        }
+        else
+        {
+            PickerArgs.InitialColorOverride = FLinearColor(m_heatmapColor.GetLowColor());
+        }
+    }
+    else
+    {
+        PickerArgs.bUseAlpha = false;
+        PickerArgs.OnColorCommitted = FOnLinearColorValueChanged::CreateRaw(this, &FTelemetryVisualizerUI::SelectDrawColor);
 
-		for (int i = 0; i < m_filterCollection.Num(); i++)
-		{
-			if (m_filterCollection[i]->name == eventName.ToString())
-			{
-				PickerArgs.InitialColorOverride = FLinearColor(m_filterCollection[i]->GetColor());
-				break;
-			}
-		}
-	}
+        for (int i = 0; i < m_filterCollection.Num(); i++)
+        {
+            if (m_filterCollection[i]->eventname == eventName.ToString())
+            {
+                PickerArgs.InitialColorOverride = FLinearColor(m_filterCollection[i]->GetColor());
+                break;
+            }
+        }
+    }
 
-	m_eventColor = eventName;
+    m_eventColor = eventName;
 
-	OpenColorPicker(PickerArgs);
+    OpenColorPicker(PickerArgs);
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 void FTelemetryVisualizerUI::SelectDrawColor(FLinearColor NewColor)
 {
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		if (m_filterCollection[i]->name == m_eventColor.ToString())
-		{
-			m_filterCollection[i]->SetColor(NewColor.Quantize());
-			m_needsActorUpdate = true;
-			break;
-		}
-	}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        if (m_filterCollection[i]->eventname == m_eventColor.ToString())
+        {
+            m_filterCollection[i]->SetColor(NewColor.Quantize());
+            m_needsActorUpdate = true;
+            break;
+        }
+    }
 
-	GenerateScrollBox();
+    GenerateScrollBox();
 }
 
 FText FTelemetryVisualizerUI::GetTypeItem(int index) const
 {
-	FString typeString = "Sphere";
+    FString typeString = "Sphere";
 
-	SEventEditorContainer* temp = m_filterCollection[index];
-	EventType currentType = temp->GetShapeType();
+    SEventEditorContainer* temp = m_filterCollection[index];
+    EventType currentType = temp->GetShapeType();
 
-	switch (currentType)
-	{
-	case EventType::Cone:
-		typeString = "Cone";
-		break;
-	case EventType::Cube:
-		typeString = "Cube";
-		break;
-	case EventType::Cylinder:
-		typeString = "Cylinder";
-		break;
-	case EventType::Plane:
-		typeString = "Plane";
-		break;
-	}
+    switch (currentType)
+    {
+    case EventType::Cone:
+        typeString = "Cone";
+        break;
+    case EventType::Cube:
+        typeString = "Cube";
+        break;
+    case EventType::Cylinder:
+        typeString = "Cylinder";
+        break;
+    case EventType::Plane:
+        typeString = "Plane";
+        break;
+    }
 
-	return FText::FromString(*typeString);
+    return FText::FromString(*typeString);
 }
 
 void FTelemetryVisualizerUI::OnTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index)
 {
-	if (NewValue.IsValid())
-	{
-		EventType newType = EventType::Sphere;
+    if (NewValue.IsValid())
+    {
+        EventType newType = EventType::Sphere;
 
-		if (*NewValue == "Cone")
-		{
-			newType = EventType::Cone;
-		}
-		else if (*NewValue == "Cube")
-		{
-			newType = EventType::Cube;
-		}
-		else if (*NewValue == "Cylinder")
-		{
-			newType = EventType::Cylinder;
-		}
-		else if (*NewValue == "Plane")
-		{
-			newType = EventType::Plane;
-		}
+        if (*NewValue == "Cone")
+        {
+            newType = EventType::Cone;
+        }
+        else if (*NewValue == "Cube")
+        {
+            newType = EventType::Cube;
+        }
+        else if (*NewValue == "Cylinder")
+        {
+            newType = EventType::Cylinder;
+        }
+        else if (*NewValue == "Plane")
+        {
+            newType = EventType::Plane;
+        }
 
-		if (m_filterCollection[index]->GetShapeType() != newType)
-		{
-			m_filterCollection[index]->SetShapeType(newType);
-			m_needsActorUpdate = true;
-		}
-	}
+        if (m_filterCollection[index]->GetShapeType() != newType)
+        {
+            m_filterCollection[index]->SetShapeType(newType);
+            m_needsActorUpdate = true;
+        }
+    }
 }
 
 void FTelemetryVisualizerUI::GenerateEventBox()
 {
-	m_eventgroupList.Empty();
-	m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
-	m_vizSelection = m_eventgroupList[0];
+    m_eventgroupList.Empty();
+    m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
+    m_vizSelection = m_eventgroupList[0];
 
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		m_eventgroupList.Add(MakeShareable<FString>(new FString(m_filterCollection[i]->name)));
-	}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        m_eventgroupList.Add(MakeShareable<FString>(new FString(m_filterCollection[i]->eventname)));
+    }
 
-	if (m_vizChoice.IsValid())
-	{
-		m_vizChoice->SetSelectedItem(m_eventgroupList[0]);
-		m_vizChoice->RefreshOptions();
-	}
+    if (m_vizChoice.IsValid())
+    {
+        m_vizChoice->SetSelectedItem(m_eventgroupList[0]);
+        m_vizChoice->RefreshOptions();
+    }
 }
 
 void FTelemetryVisualizerUI::GenerateSubEventBox(int index)
 {
-	m_eventgroupSubList.Empty();
-	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
-	m_subVizSelection = m_eventgroupSubList[0];
+    m_eventgroupSubList.Empty();
+    m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+    m_subVizSelection = m_eventgroupSubList[0];
 
-	for (auto& name : m_queryEventCollection[index].attributeNames)
-	{
-		m_eventgroupSubList.Add(MakeShareable<FString>(new FString(name)));
-	}
+    for (auto& name : m_queryEventCollection[index].attributeNames)
+    {
+        m_eventgroupSubList.Add(MakeShareable<FString>(new FString(name)));
+    }
 
-	if (m_subVizSelection.IsValid())
-	{
-		m_vizSubChoice->SetSelectedItem(m_eventgroupSubList[0]);
-		m_vizSubChoice->RefreshOptions();
-	}
+    if (m_subVizSelection.IsValid())
+    {
+        m_vizSubChoice->SetSelectedItem(m_eventgroupSubList[0]);
+        m_vizSubChoice->RefreshOptions();
+    }
 }
 
 FReply FTelemetryVisualizerUI::SelectAll()
 {
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		m_filterCollection[i]->SetShouldDraw(true);
-		m_needsActorUpdate = true;
-	}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        m_filterCollection[i]->SetShouldDraw(true);
+        m_needsActorUpdate = true;
+    }
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 FReply FTelemetryVisualizerUI::SelectNone()
 {
-	for (int i = 0; i < m_filterCollection.Num(); i++)
-	{
-		m_filterCollection[i]->SetShouldDraw(false);
-		m_needsActorUpdate = true;
-	}
+    for (int i = 0; i < m_filterCollection.Num(); i++)
+    {
+        m_filterCollection[i]->SetShouldDraw(false);
+        m_needsActorUpdate = true;
+    }
 
-	return FReply::Handled();
+    return FReply::Handled();
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerDataTab.cpp
@@ -916,6 +916,24 @@ void FTelemetryVisualizerUI::GenerateEventBox()
 	}
 }
 
+void FTelemetryVisualizerUI::GenerateSubEventBox(int index)
+{
+	m_eventgroupSubList.Empty();
+	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+	m_subVizSelection = m_eventgroupSubList[0];
+
+	for (auto& name : m_queryEventCollection[index].attributeNames)
+	{
+		m_eventgroupSubList.Add(MakeShareable<FString>(new FString(name)));
+	}
+
+	if (m_subVizSelection.IsValid())
+	{
+		m_vizSubChoice->SetSelectedItem(m_eventgroupSubList[0]);
+		m_vizSubChoice->RefreshOptions();
+	}
+}
+
 FReply FTelemetryVisualizerUI::SelectAll()
 {
 	for (int i = 0; i < m_filterCollection.Num(); i++)

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerModule.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerModule.cpp
@@ -17,11 +17,11 @@ IMPLEMENT_MODULE(FTelemetryVisualizerModule, TelemetryVisualizerModule);
 
 void FTelemetryVisualizerModule::StartupModule()
 {
-	EditorUI = TUniquePtr<FTelemetryVisualizerUI>(new FTelemetryVisualizerUI);
-	EditorUI->Initialize();
+    EditorUI = TUniquePtr<FTelemetryVisualizerUI>(new FTelemetryVisualizerUI);
+    EditorUI->Initialize();
 }
 
 void FTelemetryVisualizerModule::ShutdownModule()
 {
-	EditorUI->Shutdown();
+    EditorUI->Shutdown();
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTab.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTab.cpp
@@ -18,1177 +18,1180 @@
 //Spawns the visual tools tab layout
 TSharedRef<SDockTab> FTelemetryVisualizerUI::SpawnVizTab(const FSpawnTabArgs& TabSpawnArgs)
 {
-	TSharedRef<SDockTab> retTab = SNew(SDockTab)
-		.Label(LOCTEXT("Visualization_Tools", "Visualization Tools"))
-		.TabRole(ETabRole::NomadTab)
-		[
-			SNew(SVerticalBox)
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10.f, 5.f, 0.f, 0.f)
-			[
-				SNew(STextBlock)
-					.Text(FText::FromString("Event Type"))
-			]
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10)
-			[
-				SNew(SBorder)
-					.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
-					.Content()
-				[
-					SNew(SVerticalBox)
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 10.f, 40.f, 10.f)
-					[
-						//Event to act on
-						SAssignNew(m_vizChoice, SComboBox<TSharedPtr<FString>>)
-							.OptionsSource(&m_eventgroupList)
-							.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnVizSelectionChanged)
-							.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-							.InitiallySelectedItem(m_vizSelection)
-						[
-							SNew(STextBlock)
-								.Text_Raw(this, &FTelemetryVisualizerUI::GetCurrentVizItem)
-						]
-					]
-					//Animation Controls - Start
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 10.f, 40.f, 10.f)
-					[
-						SAssignNew(m_animationSlider, SSlider)
-							.Value(0.f)
-							.OnValueChanged_Raw(this, &FTelemetryVisualizerUI::AnimationTimelineScrolled)
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 0.f, 40.f, 10.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Left)
-						[
-							SAssignNew(m_animationCurrentTime, STextBlock)
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Right)
-						[
-							SAssignNew(m_animationTotalTime, STextBlock)
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 10.f, 40.f, 10.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Triple reverse button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, -4)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SHorizontalBox)
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-											.RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-											.RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-											.RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
-									]
-								]
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Double reverse button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, -2)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SHorizontalBox)
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-											.RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-											.RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
-									]
-								]
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Pause button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 0)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SBox)
-									.WidthOverride(MultiBoxConstants::MenuIconSize)
-									.HeightOverride(MultiBoxConstants::MenuIconSize)
-								[
-									SNew(SImage)
-										.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPause").GetIcon())
-								]
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Play button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 1)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SBox)
-									.WidthOverride(MultiBoxConstants::MenuIconSize)
-									.HeightOverride(MultiBoxConstants::MenuIconSize)
-								[
-									SNew(SImage)
-										.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-								]
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Double fast forward button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 2)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SHorizontalBox)
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-									]
-								]
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							//Triple fast forward button
-							SNew(SButton)
-								.VAlign(VAlign_Center)
-								.HAlign(HAlign_Center)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 4)
-								.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-							[
-								SNew(SHorizontalBox)
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-									]
-								]
-								+ SHorizontalBox::Slot()
-									.VAlign(VAlign_Center)
-									.HAlign(HAlign_Fill)
-								[
-									SNew(SBox)
-										.WidthOverride(MultiBoxConstants::MenuIconSize)
-										.HeightOverride(MultiBoxConstants::MenuIconSize)
-									[
-										SNew(SImage)
-											.Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
-									]
-								]
-							]
-						]
-					]
-					//Animation Controls - End
-				]
-			]
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10.f, 5.f, 0.f, 0.f)
-			[
-				SNew(STextBlock)
-					.Text(FText::FromString("Heatmap Settings"))
-			]
-			+ SVerticalBox::Slot()
-				.AutoHeight()
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(10)
-			[
-				SNew(SBorder)
-					.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
-					.Content()
-				[
-					//Heatmap Controls - Start
-					SNew(SVerticalBox)
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 10.f, 40.f, 5.f)
-					[
-						//Event to act on
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Values", "Values"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SAssignNew(m_vizSubChoice, SComboBox<TSharedPtr<FString>>)
-								.OptionsSource(&m_eventgroupSubList)
-								.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnSubVizSelectionChanged)
-								.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-								.InitiallySelectedItem(m_subVizSelection)
-							[
-								SNew(STextBlock)
-									.Text_Raw(this, &FTelemetryVisualizerUI::GetCurrentSubVizItem)
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 5.f, 40.f, 5.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Type", "Type"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SComboBox<TSharedPtr<FString>>)
-								.OptionsSource(&m_heatmapTypeList)
-								.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapTypeSelectionChanged)
-								.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-								.InitiallySelectedItem(m_heatmapTypeList[0])
-							[
-								SNew(STextBlock)
-									.Text_Raw(this, &FTelemetryVisualizerUI::GetHeatmapTypeItem)
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 5.f, 40.f, 5.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Shape", "Shape"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SComboBox<TSharedPtr<FString>>)
-								.OptionsSource(&m_shapeList)
-								.OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapShapeTypeSelectionChanged)
-								.OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
-								.InitiallySelectedItem(m_shapeList[2])
-							[
-								SNew(STextBlock)
-									.Text_Raw(this, &FTelemetryVisualizerUI::GetHeatmapShapeTypeItem)
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 5.f, 40.f, 5.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Shape_Size", "Shape Size"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SAssignNew(m_heatmapSizeText, SEditableTextBox)
-								.OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapSizeTextUpdate)
-								.Text(FText::FromString(FString::SanitizeFloat(MinHeatmapSize * 4)))
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 5.f, 40.f, 0.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Color_Range", "Color Range"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString("Low"), true)
-							[
-								SAssignNew(m_heatmapLowColorButton, SBorder)
-									.Padding(FMargin(12))
-									.BorderBackgroundColor(FSlateColor(m_heatmapColor.GetLowColor()))
-									.BorderImage(m_heatmapColor.GetLowBrush())
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SButton)
-								.OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString("High"), true)
-							[
-								SAssignNew(m_heatmapHighColorButton, SBorder)
-									.Padding(FMargin(12))
-									.BorderBackgroundColor(FSlateColor(m_heatmapColor.GetHighColor()))
-									.BorderImage(m_heatmapColor.GetHighBrush())
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 0.f, 40.f, 5.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(94.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("", ""))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("Minimum", "Minimum"))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("Maximum", "Maximum"))
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 5.f, 40.f, 5.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(SBox)
-								.WidthOverride(90.f)
-							[
-								SNew(STextBlock).Text(LOCTEXT("Type_Range", "Type Range"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 4.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SAssignNew(m_heatmapMinValueText, SEditableTextBox)
-								.OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapMinValueTextUpdate)
-								.Text(LOCTEXT("Min_Value", ""))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SAssignNew(m_heatmapMaxValueText, SEditableTextBox)
-								.OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapMaxValueTextUpdate)
-								.Text(LOCTEXT("Max_Value", ""))
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 0.f, 40.f, 10.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.AutoWidth()
-							.Padding(94.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("", ""))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("Minimum", "Minimum"))
-						]
-						+ SHorizontalBox::Slot()
-							.Padding(2.f, 0.f, 0.f, 0.f)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Fill)
-						[
-							SNew(STextBlock).Text(LOCTEXT("Maximum", "Maximum"))
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(40.f, 10.f, 40.f, 10.f)
-					[
-						SNew(SHorizontalBox)
-						+ SHorizontalBox::Slot()
-							.HAlign(HAlign_Fill)
-							.VAlign(VAlign_Center)
-						[
-							SNew(SCheckBox)
-								.IsChecked_Lambda([this]() -> ECheckBoxState
-								{
-									if (m_heatmapOrientation) return ECheckBoxState::Checked;
-									return ECheckBoxState::Unchecked;
-								})
-								.OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapOrientationChecked)
-							[
-								SNew(STextBlock)
-									.Text(FText::FromString("Use Orientation"))
-							]
-						]
-						+ SHorizontalBox::Slot()
-							.HAlign(HAlign_Fill)
-							.VAlign(VAlign_Center)
-						[
-							SNew(SCheckBox)
-								.IsChecked_Lambda([this]() -> ECheckBoxState
-								{
-									if (m_heatmapAnimation) return ECheckBoxState::Checked;
-									return ECheckBoxState::Unchecked;
-								})
-								.OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapAnimationChecked)
-							[
-								SNew(STextBlock)
-									.Text(FText::FromString("Apply to Animation"))
-							]
-						]
-					]
-					+ SVerticalBox::Slot()
-						.AutoHeight()
-						.HAlign(HAlign_Fill)
-						.VAlign(VAlign_Fill)
-						.Padding(132.f, 10.f, 40.f, 10.f)
-					[
-						SNew(SButton)
-							.VAlign(VAlign_Center)
-							.HAlign(HAlign_Center)
-							.Text(LOCTEXT("Generate", "Generate"))
-							.OnClicked_Raw(this, &FTelemetryVisualizerUI::GenerateHeatmap)
-					]
-				]
-				//Heatmap Controls - End
-			]
-		];
+    TSharedRef<SDockTab> retTab = SNew(SDockTab)
+        .Label(LOCTEXT("Visualization_Tools", "Visualization Tools"))
+        .TabRole(ETabRole::NomadTab)
+        [
+            SNew(SVerticalBox)
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10.f, 5.f, 0.f, 0.f)
+            [
+                SNew(STextBlock)
+                    .Text(FText::FromString("Event Type"))
+            ]
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10)
+            [
+                SNew(SBorder)
+                    .BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+                    .Content()
+                [
+                    SNew(SVerticalBox)
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 10.f, 40.f, 10.f)
+                    [
+                        //Event to act on
+                        SAssignNew(m_vizChoice, SComboBox<TSharedPtr<FString>>)
+                            .OptionsSource(&m_eventgroupList)
+                            .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnVizSelectionChanged)
+                            .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                            .InitiallySelectedItem(m_vizSelection)
+                        [
+                            SNew(STextBlock)
+                                .Text_Raw(this, &FTelemetryVisualizerUI::GetCurrentVizItem)
+                        ]
+                    ]
+                    //Animation Controls - Start
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 10.f, 40.f, 10.f)
+                    [
+                        SAssignNew(m_animationSlider, SSlider)
+                            .Value(0.f)
+                            .OnValueChanged_Raw(this, &FTelemetryVisualizerUI::AnimationTimelineScrolled)
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 0.f, 40.f, 10.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Left)
+                        [
+                            SAssignNew(m_animationCurrentTime, STextBlock)
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Right)
+                        [
+                            SAssignNew(m_animationTotalTime, STextBlock)
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 10.f, 40.f, 10.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Triple reverse button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, -4)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SHorizontalBox)
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                            .RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                            .RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                            .RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
+                                    ]
+                                ]
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Double reverse button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, -2)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SHorizontalBox)
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                            .RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                            .RenderTransform(FSlateRenderTransform(FQuat2D(PI), FVector2D(16.f, 16.f)))
+                                    ]
+                                ]
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Pause button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 0)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SBox)
+                                    .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                    .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                [
+                                    SNew(SImage)
+                                        .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPause").GetIcon())
+                                ]
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Play button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 1)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SBox)
+                                    .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                    .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                [
+                                    SNew(SImage)
+                                        .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                ]
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Double fast forward button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 2)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SHorizontalBox)
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                    ]
+                                ]
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            //Triple fast forward button
+                            SNew(SButton)
+                                .VAlign(VAlign_Center)
+                                .HAlign(HAlign_Center)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::PlayAnimation, 4)
+                                .ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
+                            [
+                                SNew(SHorizontalBox)
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                    ]
+                                ]
+                                + SHorizontalBox::Slot()
+                                    .VAlign(VAlign_Center)
+                                    .HAlign(HAlign_Fill)
+                                [
+                                    SNew(SBox)
+                                        .WidthOverride(MultiBoxConstants::MenuIconSize)
+                                        .HeightOverride(MultiBoxConstants::MenuIconSize)
+                                    [
+                                        SNew(SImage)
+                                            .Image(FSlateIcon(FEditorStyle::GetStyleSetName(), "GenericPlay").GetIcon())
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                    //Animation Controls - End
+                ]
+            ]
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10.f, 5.f, 0.f, 0.f)
+            [
+                SNew(STextBlock)
+                    .Text(FText::FromString("Heatmap Settings"))
+            ]
+            + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)
+                .Padding(10)
+            [
+                SNew(SBorder)
+                    .BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+                    .Content()
+                [
+                    //Heatmap Controls - Start
+                    SNew(SVerticalBox)
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 10.f, 40.f, 5.f)
+                    [
+                        //Event to act on
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Values", "Values"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SAssignNew(m_vizSubChoice, SComboBox<TSharedPtr<FString>>)
+                                .OptionsSource(&m_eventgroupSubList)
+                                .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnSubVizSelectionChanged)
+                                .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                                .InitiallySelectedItem(m_subVizSelection)
+                            [
+                                SNew(STextBlock)
+                                    .Text_Raw(this, &FTelemetryVisualizerUI::GetCurrentSubVizItem)
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 5.f, 40.f, 5.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Type", "Type"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SComboBox<TSharedPtr<FString>>)
+                                .OptionsSource(&m_heatmapTypeList)
+                                .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapTypeSelectionChanged)
+                                .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                                .InitiallySelectedItem(m_heatmapTypeList[0])
+                            [
+                                SNew(STextBlock)
+                                    .Text_Raw(this, &FTelemetryVisualizerUI::GetHeatmapTypeItem)
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 5.f, 40.f, 5.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Shape", "Shape"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SComboBox<TSharedPtr<FString>>)
+                                .OptionsSource(&m_shapeList)
+                                .OnSelectionChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapShapeTypeSelectionChanged)
+                                .OnGenerateWidget_Raw(this, &FTelemetryVisualizerUI::MakeWidgetForOption)
+                                .InitiallySelectedItem(m_shapeList[2])
+                            [
+                                SNew(STextBlock)
+                                    .Text_Raw(this, &FTelemetryVisualizerUI::GetHeatmapShapeTypeItem)
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 5.f, 40.f, 5.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Shape_Size", "Shape Size"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SAssignNew(m_heatmapSizeText, SEditableTextBox)
+                                .OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapSizeTextUpdate)
+                                .Text(FText::FromString(FString::SanitizeFloat(MinHeatmapSize * 4)))
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 5.f, 40.f, 0.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Color_Range", "Color Range"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString("Low"), true)
+                            [
+                                SAssignNew(m_heatmapLowColorButton, SBorder)
+                                    .Padding(FMargin(12))
+                                    .BorderBackgroundColor(FSlateColor(m_heatmapColor.GetLowColor()))
+                                    .BorderImage(m_heatmapColor.GetLowBrush())
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SButton)
+                                .OnClicked_Raw(this, &FTelemetryVisualizerUI::DisplayDrawColor, FText::FromString("High"), true)
+                            [
+                                SAssignNew(m_heatmapHighColorButton, SBorder)
+                                    .Padding(FMargin(12))
+                                    .BorderBackgroundColor(FSlateColor(m_heatmapColor.GetHighColor()))
+                                    .BorderImage(m_heatmapColor.GetHighBrush())
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 0.f, 40.f, 5.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(94.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("", ""))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("Minimum", "Minimum"))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("Maximum", "Maximum"))
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 5.f, 40.f, 5.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(SBox)
+                                .WidthOverride(90.f)
+                            [
+                                SNew(STextBlock).Text(LOCTEXT("Type_Range", "Type Range"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 4.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SAssignNew(m_heatmapMinValueText, SEditableTextBox)
+                                .OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapMinValueTextUpdate)
+                                .Text(LOCTEXT("Min_Value", ""))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SAssignNew(m_heatmapMaxValueText, SEditableTextBox)
+                                .OnTextCommitted_Raw(this, &FTelemetryVisualizerUI::HeatmapMaxValueTextUpdate)
+                                .Text(LOCTEXT("Max_Value", ""))
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 0.f, 40.f, 10.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .Padding(94.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("", ""))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("Minimum", "Minimum"))
+                        ]
+                        + SHorizontalBox::Slot()
+                            .Padding(2.f, 0.f, 0.f, 0.f)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Fill)
+                        [
+                            SNew(STextBlock).Text(LOCTEXT("Maximum", "Maximum"))
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(40.f, 10.f, 40.f, 10.f)
+                    [
+                        SNew(SHorizontalBox)
+                        + SHorizontalBox::Slot()
+                            .HAlign(HAlign_Fill)
+                            .VAlign(VAlign_Center)
+                        [
+                            SNew(SCheckBox)
+                                .IsChecked_Lambda([this]() -> ECheckBoxState
+                                {
+                                    if (m_heatmapOrientation) return ECheckBoxState::Checked;
+                                    return ECheckBoxState::Unchecked;
+                                })
+                                .OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapOrientationChecked)
+                            [
+                                SNew(STextBlock)
+                                    .Text(FText::FromString("Use Orientation"))
+                            ]
+                        ]
+                        + SHorizontalBox::Slot()
+                            .HAlign(HAlign_Fill)
+                            .VAlign(VAlign_Center)
+                        [
+                            SNew(SCheckBox)
+                                .IsChecked_Lambda([this]() -> ECheckBoxState
+                                {
+                                    if (m_heatmapAnimation) return ECheckBoxState::Checked;
+                                    return ECheckBoxState::Unchecked;
+                                })
+                                .OnCheckStateChanged_Raw(this, &FTelemetryVisualizerUI::OnHeatmapAnimationChecked)
+                            [
+                                SNew(STextBlock)
+                                    .Text(FText::FromString("Apply to Animation"))
+                            ]
+                        ]
+                    ]
+                    + SVerticalBox::Slot()
+                        .AutoHeight()
+                        .HAlign(HAlign_Fill)
+                        .VAlign(VAlign_Fill)
+                        .Padding(132.f, 10.f, 40.f, 10.f)
+                    [
+                        SNew(SButton)
+                            .VAlign(VAlign_Center)
+                            .HAlign(HAlign_Center)
+                            .Text(LOCTEXT("Generate", "Generate"))
+                            .OnClicked_Raw(this, &FTelemetryVisualizerUI::GenerateHeatmap)
+                    ]
+                ]
+                //Heatmap Controls - End
+            ]
+        ];
 
-	if (m_animationCurrentTime.IsValid())
-	{
-		m_animationCurrentTime->SetText(FString("0:00"));
-	}
+    if (m_animationCurrentTime.IsValid())
+    {
+        m_animationCurrentTime->SetText(FString("0:00"));
+    }
 
-	if (m_animationTotalTime.IsValid())
-	{
-		m_animationTotalTime->SetText(FString("0:00"));
-	}
+    if (m_animationTotalTime.IsValid())
+    {
+        m_animationTotalTime->SetText(FString("0:00"));
+    }
 
-	return retTab;
+    return retTab;
 }
 
 
 FText FTelemetryVisualizerUI::GetCurrentVizItem() const
 {
-	return FText::FromString(*m_vizSelection);
+    return FText::FromString(*m_vizSelection);
 }
 
 FText FTelemetryVisualizerUI::GetCurrentSubVizItem() const
 {
-	return FText::FromString(*m_subVizSelection);
+    return FText::FromString(*m_subVizSelection);
 }
 
 void FTelemetryVisualizerUI::OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
 {
-	if (NewValue.IsValid())
-	{
-		ResetRange();
+    if (NewValue.IsValid())
+    {
+        ResetRange();
 
-		m_vizSelection = NewValue;
-		m_anim_Control.Stop();
+        m_vizSelection = NewValue;
+        m_anim_Control.Stop();
 
-		for (int i = 0; i < m_queryEventCollection.Num(); i++)
-		{
-			m_queryEventCollection[i].SetShouldAnimate(false);
+        for (int i = 0; i < m_queryEventCollection.Num(); i++)
+        {
+            m_queryEventCollection[i].SetShouldAnimate(false);
 
-			if (m_queryEventCollection[i].name == *NewValue)
-			{
-				m_anim_Control.UpdateContainer(&m_queryEventCollection[i]);
-				GenerateSubEventBox(i);
-			}
-		}
+            if (m_queryEventCollection[i].eventname == *NewValue)
+            {
+                m_anim_Control.UpdateContainer(&m_queryEventCollection[i]);
+                GenerateSubEventBox(i);
+            }
+        }
 
-		if (m_animationCurrentTime.IsValid())
-		{
-			m_animationCurrentTime->SetText(FString("0:00"));
-		}
+        if (m_animationCurrentTime.IsValid())
+        {
+            m_animationCurrentTime->SetText(FString("0:00"));
+        }
 
-		if (m_animationTotalTime.IsValid())
-		{
-			FNumberFormattingOptions format;
-			format.MinimumIntegralDigits = 2;
+        if (m_animationTotalTime.IsValid())
+        {
+            FNumberFormattingOptions format;
+            format.MinimumIntegralDigits = 2;
 
-			FTimespan totalTime = m_anim_Control.GetTimespan();
-			m_animationTotalTime->SetText(FText::Format(FTextFormat::FromString("{0}:{1}"), FText::AsNumber(totalTime.GetMinutes()), FText::AsNumber(totalTime.GetSeconds(), &format)));
-		}
-	}
+            FTimespan totalTime = m_anim_Control.GetTimespan();
+            m_animationTotalTime->SetText(FText::Format(FTextFormat::FromString("{0}:{1}"), FText::AsNumber(totalTime.GetMinutes()), FText::AsNumber(totalTime.GetSeconds(), &format)));
+        }
+    }
 }
 
 void FTelemetryVisualizerUI::OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
 {
-	if (NewValue.IsValid())
-	{
-		ResetRange();
+    if (NewValue.IsValid())
+    {
+        ResetRange();
 
-		m_subVizSelection = NewValue;
-
-		ResetRange();
-	}
+        m_subVizSelection = NewValue;
+    }
 }
 
 /////////////////////////////////ANIMATION/////////////////////////////////
 void FTelemetryVisualizerUI::AnimationTimelineScrolled(float NewLevel)
 {
-	m_anim_Control.SetPlaybackTime(NewLevel);
+    m_anim_Control.SetPlaybackTime(NewLevel);
 }
 
 FReply FTelemetryVisualizerUI::PlayAnimation(int speed)
 {
-	for (int i = 0; i < m_queryEventCollection.Num(); i++)
-	{
-		m_queryEventCollection[i].SetShouldDraw(false);
-	}
+    for (int i = 0; i < m_queryEventCollection.Num(); i++)
+    {
+        m_queryEventCollection[i].SetShouldDraw(false);
+    }
 
-	GenerateScrollBox();
+    GenerateScrollBox();
 
-	m_anim_Control.Play(speed);
+    m_anim_Control.Play(speed);
 
-	return FReply::Handled();
+    return FReply::Handled();
 }
 
 /////////////////////////////////HEATMAP/////////////////////////////////
 void FTelemetryVisualizerUI::OnHeatmapOrientationChecked(ECheckBoxState NewState)
 {
-	if (NewState == ECheckBoxState::Checked)
-	{
-		m_heatmapOrientation = true;
-	}
-	else
-	{
-		m_heatmapOrientation = false;
-	}
+    if (NewState == ECheckBoxState::Checked)
+    {
+        m_heatmapOrientation = true;
+    }
+    else
+    {
+        m_heatmapOrientation = false;
+    }
 }
 
 void FTelemetryVisualizerUI::OnHeatmapAnimationChecked(ECheckBoxState NewState)
 {
-	if (NewState == ECheckBoxState::Checked)
-	{
-		m_heatmapAnimation = true;
-	}
-	else
-	{
-		m_heatmapAnimation = false;
-	}
+    if (NewState == ECheckBoxState::Checked)
+    {
+        m_heatmapAnimation = true;
+    }
+    else
+    {
+        m_heatmapAnimation = false;
+    }
 }
 
 void FTelemetryVisualizerUI::ResetRange()
 {
 
-	m_heatmapMinValue = -1;
-	m_heatmapMinValueText->SetText(FText::FromString(""));
-	m_heatmapMaxValue = -1;
-	m_heatmapMaxValueText->SetText(FText::FromString(""));
+    m_heatmapMinValue = -1;
+    m_heatmapMinValueText->SetText(FText::FromString(""));
+    m_heatmapMaxValue = -1;
+    m_heatmapMaxValueText->SetText(FText::FromString(""));
 }
 
 void FTelemetryVisualizerUI::HeatmapSizeTextUpdate(const FText& InText, ETextCommit::Type InCommitType)
 {
-	FString tempText = m_heatmapSizeText->GetText().ToString();
-	float value = FCString::Atof(*tempText);
-	value = FMath::Max(value, MinHeatmapSize);
-	value = FMath::Min(value, MaxHeatmapSize);
+    FString tempText = m_heatmapSizeText->GetText().ToString();
+    float value = FCString::Atof(*tempText);
+    value = FMath::Max(value, MinHeatmapSize);
+    value = FMath::Min(value, MaxHeatmapSize);
 
-	ResetRange();
-	m_heatmapSize = value;
+    ResetRange();
+    m_heatmapSize = value;
 
-	m_heatmapSizeText->SetText(FText::FromString(FString::SanitizeFloat(value)));
+    m_heatmapSizeText->SetText(FText::FromString(FString::SanitizeFloat(value)));
 }
 
 void FTelemetryVisualizerUI::HeatmapMinValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType)
 {
-	FString tempText = m_heatmapMinValueText->GetText().ToString();
-	int value = FCString::Atoi(*tempText);
+    FString tempText = m_heatmapMinValueText->GetText().ToString();
+    double value = FCString::Atod(*tempText);
 
-	m_heatmapMinValue = FMath::Min(value, m_heatmapMaxValue);
-	m_heatmapMinValueText->SetText(FText::FromString(FString::FromInt(value)));
+    m_heatmapMinValue = FMath::Min(value, m_heatmapMaxValue);
+    m_heatmapMinValueText->SetText(FText::FromString(FString::SanitizeFloat(value)));
 }
 
 void FTelemetryVisualizerUI::HeatmapMaxValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType)
 {
-	FString tempText = m_heatmapMaxValueText->GetText().ToString();
-	int value = FCString::Atoi(*tempText);
+    FString tempText = m_heatmapMaxValueText->GetText().ToString();
+    double value = FCString::Atod(*tempText);
 
-	m_heatmapMaxValue = FMath::Max(value, m_heatmapMinValue);
-	m_heatmapMaxValueText->SetText(FText::FromString(FString::FromInt(value)));
+    m_heatmapMaxValue = FMath::Max(value, m_heatmapMinValue);
+    m_heatmapMaxValueText->SetText(FText::FromString(FString::SanitizeFloat(value)));
 }
 
 FText FTelemetryVisualizerUI::GetHeatmapTypeItem() const
 {
-	FString typeString = "Population";
+    FString typeString = "Population";
 
-	switch (m_heatmapType)
-	{
-	case HeatmapType::Value:
-		typeString = "Value";
-		break;
-	case HeatmapType::Population_Bar:
-		typeString = "Population - Bar";
-		break;
-	case HeatmapType::Value_Bar:
-		typeString = "Value - Bar";
-		break;
-	}
+    switch (m_heatmapType)
+    {
+    case HeatmapType::Value:
+        typeString = "Value";
+        break;
+    case HeatmapType::Population_Bar:
+        typeString = "Population - Bar";
+        break;
+    case HeatmapType::Value_Bar:
+        typeString = "Value - Bar";
+        break;
+    }
 
-	return FText::FromString(*typeString);
+    return FText::FromString(*typeString);
 }
 
 FText FTelemetryVisualizerUI::GetHeatmapShapeTypeItem() const
 {
-	FString typeString = "Sphere";
+    FString typeString = "Sphere";
 
-	switch (m_heatmapShapeType)
-	{
-	case EventType::Cone:
-		typeString = "Cone";
-		break;
-	case EventType::Cube:
-		typeString = "Cube";
-		break;
-	case EventType::Cylinder:
-		typeString = "Cylinder";
-		break;
-	case EventType::Plane:
-		typeString = "Plane";
-		break;
-	}
+    switch (m_heatmapShapeType)
+    {
+    case EventType::Cone:
+        typeString = "Cone";
+        break;
+    case EventType::Cube:
+        typeString = "Cube";
+        break;
+    case EventType::Cylinder:
+        typeString = "Cylinder";
+        break;
+    case EventType::Plane:
+        typeString = "Plane";
+        break;
+    }
 
-	return FText::FromString(*typeString);
+    return FText::FromString(*typeString);
 }
 
 void FTelemetryVisualizerUI::OnHeatmapTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
 {
-	if (NewValue.IsValid())
-	{
-		HeatmapType newType = HeatmapType::Population;
+    if (NewValue.IsValid())
+    {
+        HeatmapType newType = HeatmapType::Population;
 
-		if (*NewValue == "Value")
-		{
-			newType = HeatmapType::Value;
-		}
-		else if (*NewValue == "Population - Bar")
-		{
-			newType = HeatmapType::Population_Bar;
-		}
-		else if (*NewValue == "Value - Bar")
-		{
-			newType = HeatmapType::Value_Bar;
-		}
+        if (*NewValue == "Value")
+        {
+            newType = HeatmapType::Value;
+        }
+        else if (*NewValue == "Population - Bar")
+        {
+            newType = HeatmapType::Population_Bar;
+        }
+        else if (*NewValue == "Value - Bar")
+        {
+            newType = HeatmapType::Value_Bar;
+        }
 
-		m_heatmapType = newType;
+        m_heatmapType = newType;
 
-		ResetRange();
-	}
+        ResetRange();
+    }
 }
 
 void FTelemetryVisualizerUI::OnHeatmapShapeTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type)
 {
-	if (NewValue.IsValid())
-	{
-		EventType newType = EventType::Sphere;
+    if (NewValue.IsValid())
+    {
+        EventType newType = EventType::Sphere;
 
-		if (*NewValue == "Cone")
-		{
-			newType = EventType::Cone;
-		}
-		else if (*NewValue == "Cube")
-		{
-			newType = EventType::Cube;
-		}
-		else if (*NewValue == "Cylinder")
-		{
-			newType = EventType::Cylinder;
-		}
-		else if (*NewValue == "Plane")
-		{
-			newType = EventType::Plane;
-		}
+        if (*NewValue == "Cone")
+        {
+            newType = EventType::Cone;
+        }
+        else if (*NewValue == "Cube")
+        {
+            newType = EventType::Cube;
+        }
+        else if (*NewValue == "Cylinder")
+        {
+            newType = EventType::Cylinder;
+        }
+        else if (*NewValue == "Plane")
+        {
+            newType = EventType::Plane;
+        }
 
-		m_heatmapShapeType = newType;
-	}
+        m_heatmapShapeType = newType;
+    }
 }
 
 void FTelemetryVisualizerUI::SelectHeatmapDrawColor(FLinearColor NewColor)
 {
-	if (m_eventColor.ToString() == "High")
-	{
-		m_heatmapColor.SetHighColor(NewColor.Quantize());
+    if (m_eventColor.ToString() == "High")
+    {
+        m_heatmapColor.SetHighColor(NewColor.Quantize());
 
-		m_heatmapHighColorButton->SetBorderBackgroundColor(FSlateColor(m_heatmapColor.GetHighColor()));
-		m_heatmapHighColorButton->SetBorderImage(m_heatmapColor.GetHighBrush());
-	}
-	else
-	{
-		m_heatmapColor.SetLowColor(NewColor.Quantize());
+        m_heatmapHighColorButton->SetBorderBackgroundColor(FSlateColor(m_heatmapColor.GetHighColor()));
+        m_heatmapHighColorButton->SetBorderImage(m_heatmapColor.GetHighBrush());
+    }
+    else
+    {
+        m_heatmapColor.SetLowColor(NewColor.Quantize());
 
-		m_heatmapLowColorButton->SetBorderBackgroundColor(FSlateColor(m_heatmapColor.GetLowColor()));
-		m_heatmapLowColorButton->SetBorderImage(m_heatmapColor.GetLowBrush());
-	}
+        m_heatmapLowColorButton->SetBorderBackgroundColor(FSlateColor(m_heatmapColor.GetLowColor()));
+        m_heatmapLowColorButton->SetBorderImage(m_heatmapColor.GetLowBrush());
+    }
 }
 
 //Generates a heatmap for all events
 FReply FTelemetryVisualizerUI::GenerateHeatmap()
 {
-	SEventEditorContainer* collection = nullptr;
+    SEventEditorContainer* collection = nullptr;
 
-	for (int i = 0; i < m_queryEventCollection.Num(); i++)
-	{
-		m_queryEventCollection[i].SetShouldAnimate(false);
-		m_queryEventCollection[i].SetShouldDraw(false);
+    for (int i = 0; i < m_queryEventCollection.Num(); i++)
+    {
+        m_queryEventCollection[i].SetShouldAnimate(false);
+        m_queryEventCollection[i].SetShouldDraw(false);
 
-		if (m_queryEventCollection[i].name == *m_vizSelection)
-		{
-			collection = &m_queryEventCollection[i];
-		}
-	}
+        if (m_queryEventCollection[i].eventname == *m_vizSelection)
+        {
+            collection = &m_queryEventCollection[i];
+        }
+    }
 
-	if (collection == nullptr)
-	{
-		return FReply::Handled();
-	}
+    if (collection == nullptr)
+    {
+        return FReply::Handled();
+    }
 
-	return GenerateHeatmap(collection, 0, collection->events.Num() - 1);
+    return GenerateHeatmap(collection, 0, collection->events.Num() - 1);
 }
 
 //Generate a heatmap for the range of events
 FReply FTelemetryVisualizerUI::GenerateHeatmap(SEventEditorContainer* collection, int first, int last)
 {
-	DestroyActors();
-	UWorld* currentTarget = GetLocalWorld();
+    DestroyActors();
+    UWorld* currentTarget = GetLocalWorld();
 
-	if (currentTarget != nullptr && collection != nullptr && *m_subVizSelection != "")
-	{
-		if ((first == 0 && first == last) || (first == collection->events.Num() - 1 && first == last))
-		{
-			first = 0;
-			last = collection->events.Num() - 1;
-		}
+    if (currentTarget != nullptr && collection != nullptr && *m_subVizSelection != "")
+    {
+        if ((first == 0 && first == last) || (first == collection->events.Num() - 1 && first == last))
+        {
+            first = 0;
+            last = collection->events.Num() - 1;
+        }
 
-		//Segment the world in to blocks of the specified size encompassing all points
-		FVector origin = collection->GetPointRange(first, last).GetCenter();
-		FVector size(m_heatmapSize, m_heatmapSize, m_heatmapSize);
+        //Segment the world in to blocks of the specified size encompassing all points
+        FVector origin = collection->GetPointRange(first, last).GetCenter();
+        FVector size(m_heatmapSize, m_heatmapSize, m_heatmapSize);
 
-		//For each segment, collect all of the points inside and decide what data to watch based on the heatmap type
-		float scaledHeatmapSize = m_heatmapSize / 100;
-		ATelemetryEvent* tempActor;
-		FString tempName = "Heatmap";
-		FVector tempPoint;
-		TMap<FVector, HeatmapNode> heatmapNodes;
+        //For each segment, collect all of the points inside and decide what data to watch based on the heatmap type
+        float scaledHeatmapSize = m_heatmapSize / 100;
+        ATelemetryEvent* tempActor;
+        FString tempName = "Heatmap";
+        FVector tempPoint;
+        TMap<FVector, HeatmapNode> heatmapNodes;
 
-		FActorSpawnParameters params;
-		params.Name = *tempName;
+        FActorSpawnParameters params;
+        params.Name = *tempName;
 
-		if (m_heatmapMinValue == -1 && m_heatmapMaxValue == -1)
-		{
-			int largestValue = 0;
-			int largestNumValue = 0;
+        if (m_heatmapMinValue == -1 && m_heatmapMaxValue == -1)
+        {
+            double largestValue = 0;
+            double smallestValue = 0;
+            int largestNumValue = 0;
 
-			if (m_heatmapOrientation)
-			{
-				for (int j = first; j <= last; j++)
-				{
-					tempPoint = (collection->events[j]->point - origin) / size;
-					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
-					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
-					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+            if (m_heatmapOrientation)
+            {
+                for (int j = first; j <= last; j++)
+                {
+                    tempPoint = (collection->events[j]->point - origin) / size;
+                    tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+                    tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+                    tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
 
-					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+                    HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
 
-					tempEvent.numValues++;
-					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
-					tempEvent.orientation += collection->events[j]->orientation;
+                    tempEvent.numValues++;
+                    tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+                    tempEvent.orientation += collection->events[j]->orientation;
 
-					largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
-					largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
-				}
+                    smallestValue = FMath::Min(smallestValue, tempEvent.values / tempEvent.numValues);
+                    largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
+                    largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
+                }
 
-				for (auto& node : heatmapNodes)
-				{
-					node.Value.orientation = node.Value.orientation / node.Value.numValues;
-				}
-			}
-			else
-			{
-				for (int j = first; j <= last; j++)
-				{
-					tempPoint = (collection->events[j]->point - origin) / size;
-					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
-					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
-					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+                for (auto& node : heatmapNodes)
+                {
+                    node.Value.orientation = node.Value.orientation / node.Value.numValues;
+                }
+            }
+            else
+            {
+                for (int j = first; j <= last; j++)
+                {
+                    tempPoint = (collection->events[j]->point - origin) / size;
+                    tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+                    tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+                    tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
 
-					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+                    HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
 
-					tempEvent.numValues++;
-					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+                    tempEvent.numValues++;
+                    tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
 
-					largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
-					largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
-				}
-			}
+                    smallestValue = FMath::Min(smallestValue, tempEvent.values / tempEvent.numValues);
+                    largestValue = FMath::Max(largestValue, tempEvent.values / tempEvent.numValues);
+                    largestNumValue = FMath::Max(largestNumValue, tempEvent.numValues);
+                }
+            }
 
-			m_heatmapMinValue = 0;
+            m_heatmapMinValue = 0;
 
-			if (m_heatmapType == HeatmapType::Value || m_heatmapType == HeatmapType::Value_Bar)
-			{
-				if (m_subVizSelection->StartsWith("pct_"))
-				{
-					m_heatmapMaxValue = 100;
-				}
-				else
-				{
-					m_heatmapMaxValue = largestValue;
-				}
-			}
-			else
-			{
-				m_heatmapMaxValue = largestNumValue;
-			}
+            if (m_heatmapType == HeatmapType::Value || m_heatmapType == HeatmapType::Value_Bar)
+            {
+                if (m_subVizSelection->StartsWith("pct_"))
+                {
+                    m_heatmapMinValue = 0;
+                    m_heatmapMaxValue = 100;
+                }
+                else
+                {
+                    m_heatmapMinValue = smallestValue;
+                    m_heatmapMaxValue = largestValue;
+                }
+            }
+            else
+            {
+                m_heatmapMaxValue = largestNumValue;
+            }
 
-			m_heatmapMinValueText->SetText(FText::FromString("0"));
-			m_heatmapMaxValueText->SetText(FText::FromString(FString::FromInt(m_heatmapMaxValue)));
-		}
-		else
-		{
-			if (m_heatmapOrientation)
-			{
-				for (int j = first; j <= last; j++)
-				{
-					tempPoint = (collection->events[j]->point - origin) / size;
-					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
-					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
-					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+            m_heatmapMinValueText->SetText(FText::FromString(FString::SanitizeFloat(m_heatmapMinValue)));
+            m_heatmapMaxValueText->SetText(FText::FromString(FString::SanitizeFloat(m_heatmapMaxValue)));
+        }
+        else
+        {
+            if (m_heatmapOrientation)
+            {
+                for (int j = first; j <= last; j++)
+                {
+                    tempPoint = (collection->events[j]->point - origin) / size;
+                    tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+                    tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+                    tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
 
-					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+                    HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
 
-					tempEvent.numValues++;
-					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
-					tempEvent.orientation += collection->events[j]->orientation;
-				}
+                    tempEvent.numValues++;
+                    tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+                    tempEvent.orientation += collection->events[j]->orientation;
+                }
 
-				for (auto& node : heatmapNodes)
-				{
-					node.Value.orientation = node.Value.orientation / node.Value.numValues;
-				}
-			}
-			else
-			{
-				for (int j = first; j <= last; j++)
-				{
-					tempPoint = (collection->events[j]->point - origin) / size;
-					tempPoint.X = FMath::FloorToFloat(tempPoint.X);
-					tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
-					tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
+                for (auto& node : heatmapNodes)
+                {
+                    node.Value.orientation = node.Value.orientation / node.Value.numValues;
+                }
+            }
+            else
+            {
+                for (int j = first; j <= last; j++)
+                {
+                    tempPoint = (collection->events[j]->point - origin) / size;
+                    tempPoint.X = FMath::FloorToFloat(tempPoint.X);
+                    tempPoint.Y = FMath::FloorToFloat(tempPoint.Y);
+                    tempPoint.Z = FMath::FloorToFloat(tempPoint.Z);
 
-					HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
+                    HeatmapNode& tempEvent = heatmapNodes.FindOrAdd(tempPoint);
 
-					tempEvent.numValues++;
-					tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
-				}
-			}
-		}
+                    tempEvent.numValues++;
+                    tempEvent.values += collection->events[j]->GetValue(*m_subVizSelection);
+                }
+            }
+        }
 
-		if(heatmapNodes.Num() > 0)
-		{
-			//For each section, add instanced mesh to the master mesh and set its shape and color as needed
-			tempActor = currentTarget->SpawnActor<ATelemetryEvent>(FVector::ZeroVector, FRotator::ZeroRotator, params);
-			tempActor->SetActorLabel(*tempName);
+        if(heatmapNodes.Num() > 0)
+        {
+            //For each section, add instanced mesh to the master mesh and set its shape and color as needed
+            tempActor = currentTarget->SpawnActor<ATelemetryEvent>(FVector::ZeroVector, FRotator::ZeroRotator, params);
+            tempActor->SetActorLabel(*tempName);
 
-			float tempValue;
-			float tempColorValue;
+            double tempValue;
+            float tempColorValue;
 
-			if (m_heatmapType == HeatmapType::Value)
-			{
-				for (auto& node : heatmapNodes)
-				{
-					tempValue = (float)node.Value.values / node.Value.numValues;
-					tempColorValue = (tempValue - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+            if (m_heatmapType == HeatmapType::Value)
+            {
+                for (auto& node : heatmapNodes)
+                {
+                    tempValue = (double)node.Value.values / node.Value.numValues;
+                    tempColorValue = (tempValue - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+                    tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
 
-					tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
-				}
-			}
-			else if (m_heatmapType == HeatmapType::Population)
-			{
-				for (auto& node : heatmapNodes)
-				{
-					tempValue = (float)node.Value.numValues / m_heatmapMaxValue;
-					tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+                    tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
+                }
+            }
+            else if (m_heatmapType == HeatmapType::Population)
+            {
+                for (auto& node : heatmapNodes)
+                {
+                    tempValue = (double)node.Value.numValues / m_heatmapMaxValue;
+                    tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+                    tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
 
-					tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
-				}
-			}
-			else if (m_heatmapType == HeatmapType::Value_Bar)
-			{
-				float tempHeight;
+                    tempActor->AddEvent((node.Key * size) + origin, node.Value.orientation, m_heatmapColor.GetColorFromRange(tempColorValue), m_heatmapShapeType, scaledHeatmapSize, tempValue);
+                }
+            }
+            else if (m_heatmapType == HeatmapType::Value_Bar)
+            {
+                float tempHeight;
 
-				for (auto& node : heatmapNodes)
-				{
-					tempValue = (float)node.Value.values / node.Value.numValues;
-					tempColorValue = (tempValue - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
-					tempHeight = (((float)node.Value.values / node.Value.numValues) / m_heatmapMaxValue) * scaledHeatmapSize;
+                for (auto& node : heatmapNodes)
+                {
+                    tempValue = (double)node.Value.values / node.Value.numValues;
+                    tempColorValue = (tempValue - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+                    tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+                    tempHeight = (((double)node.Value.values / node.Value.numValues) / m_heatmapMaxValue) * scaledHeatmapSize;
 
-					tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
-						FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
-				}
-			}
-			else if (m_heatmapType == HeatmapType::Population_Bar)
-			{
-				float tempHeight;
+                    tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
+                        FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
+                }
+            }
+            else if (m_heatmapType == HeatmapType::Population_Bar)
+            {
+                float tempHeight;
 
-				for (auto& node : heatmapNodes)
-				{
-					tempValue = (float)node.Value.numValues / m_heatmapMaxValue;
-					tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
-					tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
-					tempHeight = ((float)node.Value.numValues / m_heatmapMaxValue) * scaledHeatmapSize;
+                for (auto& node : heatmapNodes)
+                {
+                    tempValue = (double)node.Value.numValues / m_heatmapMaxValue;
+                    tempColorValue = (float)(node.Value.numValues - m_heatmapMinValue) / (m_heatmapMaxValue - m_heatmapMinValue);
+                    tempColorValue = FMath::Clamp(tempColorValue, 0.f, 1.f);
+                    tempHeight = ((double)node.Value.numValues / m_heatmapMaxValue) * scaledHeatmapSize;
 
-					tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
-						FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
-				}
-			}
+                    tempActor->AddEvent((node.Key * size) + origin, FVector::ZeroVector, m_heatmapColor.GetColorFromRange(tempColorValue), EventType::Cube,
+                        FBox::BuildAABB(FVector(0, 0, (tempHeight / 2) * 100), FVector(scaledHeatmapSize, scaledHeatmapSize, tempHeight)), tempValue);
+                }
+            }
 
-			tempName = "/TelemetryEvents";
-			tempActor->SetFolderPath(*tempName);
+            tempName = "/TelemetryEvents";
+            tempActor->SetFolderPath(*tempName);
 
-			m_eventActors.Add(tempActor);
-		}
-	}
+            m_eventActors.Add(tempActor);
+        }
+    }
 
-	return FReply::Handled();
+    return FReply::Handled();
 }

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTypes.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerTypes.h
@@ -19,854 +19,854 @@ static const bool DefaultDrawSetting = true;
 //Set of default colors for drawing events
 static const TArray<FColor> DefaultColors =
 {
-	FColor::Red,
-	FColor::Green,
-	FColor::Blue,
-	FColor::Yellow,
-	FColor::Cyan,
-	FColor::Magenta,
-	FColor::Orange,
-	FColor::Purple,
-	FColor::Turquoise,
-	FColor::Silver,
-	FColor::Emerald
+    FColor::Red,
+    FColor::Green,
+    FColor::Blue,
+    FColor::Yellow,
+    FColor::Cyan,
+    FColor::Magenta,
+    FColor::Orange,
+    FColor::Purple,
+    FColor::Turquoise,
+    FColor::Silver,
+    FColor::Emerald
 };
 
 //Primary container for events managed by the UI
 struct STelemetryEvent
 {
-	TCHAR user[128];
-	TCHAR build[128];
-	TCHAR name[128];
-	TCHAR category[128];
-	TCHAR session[38];
-	FVector point;
-	FVector orientation;
-	FDateTime time;
-	TMap<FString, TSharedPtr<FJsonValue>> values;
+    TCHAR user[128];
+    TCHAR build[128];
+    TCHAR eventname[128];
+    TCHAR category[128];
+    TCHAR session[38];
+    FVector point;
+    FVector orientation;
+    FDateTime time;
+    TMap<FString, TSharedPtr<FJsonValue>> values;
 
-	STelemetryEvent() : name(TEXT("\0")), category(TEXT("\0")), session(TEXT("\0")), user(TEXT("\0")), build(TEXT("\0")), point(FVector::ZeroVector), orientation(FVector::ZeroVector), time(0) {};
-	STelemetryEvent(FString inName, FString inCategory, FString inSession, FString inBuild, FString inUser, FVector point, FVector orientation, FDateTime time)
-		: point(point), orientation(orientation), time(time)
-	{
-		SetName(inName);
-		SetCategory(inCategory);
-		SetSession(inSession);
-		SetBuild(inBuild);
-		SetUser(inUser);
-	};
+    STelemetryEvent() : eventname(TEXT("\0")), category(TEXT("\0")), session(TEXT("\0")), user(TEXT("\0")), build(TEXT("\0")), point(FVector::ZeroVector), orientation(FVector::ZeroVector), time(0) {};
+    STelemetryEvent(FString inName, FString inCategory, FString inSession, FString inBuild, FString inUser, FVector point, FVector orientation, FDateTime time)
+        : point(point), orientation(orientation), time(time)
+    {
+        SetName(inName);
+        SetCategory(inCategory);
+        SetSession(inSession);
+        SetBuild(inBuild);
+        SetUser(inUser);
+    };
 
-	void SetName(FString inName)
-	{
-		if (inName.Len() < 128)
-		{
-			FCString::Strcpy(name, *inName);
-		}
-	}
+    void SetName(FString inName)
+    {
+        if (inName.Len() < 128)
+        {
+            FCString::Strcpy(eventname, *inName);
+        }
+    }
 
-	FString GetName()
-	{
-		return FString(name);
-	}
+    FString GetName()
+    {
+        return FString(eventname);
+    }
 
-	void SetCategory(FString inCategory)
-	{
-		if (inCategory.Len() < 128)
-		{
-			FCString::Strcpy(category, *inCategory);
-		}
-	}
+    void SetCategory(FString inCategory)
+    {
+        if (inCategory.Len() < 128)
+        {
+            FCString::Strcpy(category, *inCategory);
+        }
+    }
 
-	FString GetCategory()
-	{
-		return FString(category);
-	}
+    FString GetCategory()
+    {
+        return FString(category);
+    }
 
-	void SetBuild(FString inBuild)
-	{
-		if (inBuild.Len() < 128)
-		{
-			FCString::Strcpy(build, *inBuild);
-		}
-	}
+    void SetBuild(FString inBuild)
+    {
+        if (inBuild.Len() < 128)
+        {
+            FCString::Strcpy(build, *inBuild);
+        }
+    }
 
-	FString GetBuild()
-	{
-		return FString(build);
-	}
+    FString GetBuild()
+    {
+        return FString(build);
+    }
 
-	void SetUser(FString inUser)
-	{
-		if (inUser.Len() < 128)
-		{
-			FCString::Strcpy(user, *inUser);
-		}
-	}
+    void SetUser(FString inUser)
+    {
+        if (inUser.Len() < 128)
+        {
+            FCString::Strcpy(user, *inUser);
+        }
+    }
 
-	FString GetUser()
-	{
-		return FString(user);
-	}
+    FString GetUser()
+    {
+        return FString(user);
+    }
 
-	void SetSession(FString inSession)
-	{
-		if (inSession.Len() < 38)
-		{
-			FCString::Strcpy(session, *inSession);
-		}
-	}
+    void SetSession(FString inSession)
+    {
+        if (inSession.Len() < 38)
+        {
+            FCString::Strcpy(session, *inSession);
+        }
+    }
 
-	FString GetSession()
-	{
-		return FString(session);
-	}
+    FString GetSession()
+    {
+        return FString(session);
+    }
 
-	double GetValue(FString name)
-	{
-		double value = 0;
+    double GetValue(FString key)
+    {
+        double value = 0;
 
-		if (values.Contains(name))
-		{
-			values[name]->TryGetNumber(value);
-		}
+        if (values.Contains(key))
+        {
+            values[key]->TryGetNumber(value);
+        }
 
-		return value;
-	}
+        return value;
+    }
 };
 
 //Wrapper for the event container with draw information
 struct SEventEditorContainer
 {
 private:
-	FColor color;
-	FSlateBrush colorBrush;
-	bool shouldDraw;
-	bool shouldAnimate;
-	FDateTime timeStart;
-	FDateTime timeEnd;
-	EventType type;
+    FColor color;
+    FSlateBrush colorBrush;
+    bool shouldDraw;
+    bool shouldAnimate;
+    FDateTime timeStart;
+    FDateTime timeEnd;
+    EventType type;
 
 public:
-	FString name;
-	FString session;
-	TArray<TSharedPtr<STelemetryEvent>> events;
-	TArray<FString> attributeNames;
+    FString eventname;
+    FString session;
+    TArray<TSharedPtr<STelemetryEvent>> events;
+    TArray<FString> attributeNames;
 
-	SEventEditorContainer() : shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
-	{
-	}
+    SEventEditorContainer() : shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
+    {
+    }
 
-	SEventEditorContainer(FString name, int index) : name(name), shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
-	{
-		color = DefaultColors[index % DefaultColors.Num()];
-		colorBrush = (FSlateBrush)FSlateColorBrush(color);
-	}
+    SEventEditorContainer(FString inName, int index) : eventname(inName), shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
+    {
+        color = DefaultColors[index % DefaultColors.Num()];
+        colorBrush = (FSlateBrush)FSlateColorBrush(color);
+    }
 
-	SEventEditorContainer(TArray<FSimpleEvent> iEvents) : shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
-	{
-		if (iEvents.Num() > 0)
-		{
-			Fill(iEvents);
-			name = iEvents[0].GetName();
-			SetupTimes();
-		}
-	}
+    SEventEditorContainer(TArray<FSimpleEvent> iEvents) : shouldDraw(DefaultDrawSetting), shouldAnimate(false), color(FColor::Red), colorBrush((FSlateBrush)FSlateColorBrush(FColor::Red)), type(EventType::Sphere)
+    {
+        if (iEvents.Num() > 0)
+        {
+            Fill(iEvents);
+            eventname = iEvents[0].GetName();
+            SetupTimes();
+        }
+    }
 
-	void AddEvent(FSimpleEvent newEvent)
-	{
-		int index = events.Emplace(MakeShareable(new STelemetryEvent(
-			newEvent.GetName(),
-			newEvent.GetCategory(),
-			newEvent.GetSessionId(),
-			newEvent.GetBuildType() + L" " + newEvent.GetBuildId() + L" " + newEvent.GetPlatform(),
-			newEvent.GetUserId(),
-			newEvent.GetPlayerPosition(),
-			newEvent.GetPlayerDirection(),
-			newEvent.GetTime())));
-		SetupTimes();
+    void AddEvent(FSimpleEvent newEvent)
+    {
+        int index = events.Emplace(MakeShareable(new STelemetryEvent(
+            newEvent.GetName(),
+            newEvent.GetCategory(),
+            newEvent.GetSessionId(),
+            newEvent.GetBuildType() + L" " + newEvent.GetBuildId() + L" " + newEvent.GetPlatform(),
+            newEvent.GetUserId(),
+            newEvent.GetPlayerPosition(),
+            newEvent.GetPlayerDirection(),
+            newEvent.GetTime())));
+        SetupTimes();
 
-		newEvent.GetAttributes(events[index]->values);
+        newEvent.GetAttributes(events[index]->values);
 
-		for (auto& attr : events[index]->values)
-		{
-			attributeNames.AddUnique(attr.Key);
-		}
-	}
+        for (auto& attr : events[index]->values)
+        {
+            attributeNames.AddUnique(attr.Key);
+        }
+    }
 
-	//Add an array of query results
-	void Fill(TArray<FSimpleEvent> iEvents)
-	{
-		for (auto newEvent : iEvents)
-		{
-			AddEvent(newEvent);
-		}
-	}
+    //Add an array of query results
+    void Fill(TArray<FSimpleEvent> iEvents)
+    {
+        for (auto newEvent : iEvents)
+        {
+            AddEvent(newEvent);
+        }
+    }
 
-	//Keep a timespan for the event collection
-	void SetupTimes()
-	{
-		timeStart = events[events.Num() - 1]->time;
-		timeEnd = events[0]->time;
-	}
+    //Keep a timespan for the event collection
+    void SetupTimes()
+    {
+        timeStart = events[events.Num() - 1]->time;
+        timeEnd = events[0]->time;
+    }
 
-	//Provides the total timespan for all events
-	FTimespan GetTimespan()
-	{
-		return timeEnd - timeStart;
-	}
+    //Provides the total timespan for all events
+    FTimespan GetTimespan()
+    {
+        return timeEnd - timeStart;
+    }
 
-	//Provides a percent location based on tick time
-	float GetTimeScaleFromTime(FTimespan inTime)
-	{
-		return (float)FTimespan::Ratio(inTime, timeEnd - timeStart);
-	}
+    //Provides a percent location based on tick time
+    float GetTimeScaleFromTime(FTimespan inTime)
+    {
+        return (float)FTimespan::Ratio(inTime, timeEnd - timeStart);
+    }
 
-	//Provides a percent location based on the element
-	float GetEventTimeScale(int i)
-	{
-		return (float)FTimespan::Ratio(events[events.Num() - 1 - i]->time - timeStart, timeEnd - timeStart);
-	}
+    //Provides a percent location based on the element
+    float GetEventTimeScale(int i)
+    {
+        return (float)FTimespan::Ratio(events[events.Num() - 1 - i]->time - timeStart, timeEnd - timeStart);
+    }
 
-	//Provides an element based on the percent location
-	int GetEventIndexForTimeScale(float scale)
-	{
-		int i;
-		FDateTime targetValue = timeStart + ((timeEnd - timeStart) * scale);
+    //Provides an element based on the percent location
+    int GetEventIndexForTimeScale(float scale)
+    {
+        int i;
+        FDateTime targetValue = timeStart + ((timeEnd - timeStart) * scale);
 
-		for (i = events.Num() - 1; i > 0; i--)
-		{
-			if (events[i]->time > targetValue) break;
-		}
+        for (i = events.Num() - 1; i > 0; i--)
+        {
+            if (events[i]->time > targetValue) break;
+        }
 
-		return i;
-	}
+        return i;
+    }
 
-	FSlateBrush* GetBrush()
-	{
-		return &colorBrush;
-	}
+    FSlateBrush* GetBrush()
+    {
+        return &colorBrush;
+    }
 
-	void SetColor(FColor inColor)
-	{
-		color = inColor;
-		colorBrush = (FSlateBrush)FSlateColorBrush(color);
-	}
+    void SetColor(FColor inColor)
+    {
+        color = inColor;
+        colorBrush = (FSlateBrush)FSlateColorBrush(color);
+    }
 
-	FColor GetColor()
-	{
-		return color;
-	}
+    FColor GetColor()
+    {
+        return color;
+    }
 
-	bool ShouldDraw()
-	{
-		return shouldDraw;
-	}
+    bool ShouldDraw()
+    {
+        return shouldDraw;
+    }
 
-	void SetShouldDraw(bool inBool)
-	{
-		shouldDraw = inBool;
-	}
+    void SetShouldDraw(bool inBool)
+    {
+        shouldDraw = inBool;
+    }
 
-	bool ShouldAnimate()
-	{
-		return shouldAnimate;
-	}
+    bool ShouldAnimate()
+    {
+        return shouldAnimate;
+    }
 
-	void SetShouldAnimate(bool inBool)
-	{
-		shouldAnimate = inBool;
-	}
+    void SetShouldAnimate(bool inBool)
+    {
+        shouldAnimate = inBool;
+    }
 
-	void SetShapeType(EventType inType)
-	{
-		type = inType;
-	}
+    void SetShapeType(EventType inType)
+    {
+        type = inType;
+    }
 
-	EventType GetShapeType()
-	{
-		return type;
-	}
+    EventType GetShapeType()
+    {
+        return type;
+    }
 
-	//Gets the box for where events happen (for heatmap)
-	FBox GetPointRange()
-	{
-		return GetPointRange(0, events.Num() - 1);
-	}
+    //Gets the box for where events happen (for heatmap)
+    FBox GetPointRange()
+    {
+        return GetPointRange(0, events.Num() - 1);
+    }
 
-	//Gets the box for where specified events happen (for heatmap animations)
-	FBox GetPointRange(int start, int end)
-	{
-		FBox range(FVector(FLT_MAX, FLT_MAX, FLT_MAX), FVector(-FLT_MAX, -FLT_MAX, -FLT_MAX));
+    //Gets the box for where specified events happen (for heatmap animations)
+    FBox GetPointRange(int start, int end)
+    {
+        FBox range(FVector(FLT_MAX, FLT_MAX, FLT_MAX), FVector(-FLT_MAX, -FLT_MAX, -FLT_MAX));
 
-		for (int i = start; i <= end; i++)
-		{
-			range.Min.X = FMath::Min(range.Min.X, events[i]->point.X);
-			range.Min.Y = FMath::Min(range.Min.Y, events[i]->point.Y);
-			range.Min.Z = FMath::Min(range.Min.Z, events[i]->point.Z);
-			range.Max.X = FMath::Max(range.Max.X, events[i]->point.X);
-			range.Max.Y = FMath::Max(range.Max.Y, events[i]->point.Y);
-			range.Max.Z = FMath::Max(range.Max.Z, events[i]->point.Z);
-		}
+        for (int i = start; i <= end; i++)
+        {
+            range.Min.X = FMath::Min(range.Min.X, events[i]->point.X);
+            range.Min.Y = FMath::Min(range.Min.Y, events[i]->point.Y);
+            range.Min.Z = FMath::Min(range.Min.Z, events[i]->point.Z);
+            range.Max.X = FMath::Max(range.Max.X, events[i]->point.X);
+            range.Max.Y = FMath::Max(range.Max.Y, events[i]->point.Y);
+            range.Max.Z = FMath::Max(range.Max.Z, events[i]->point.Z);
+        }
 
-		return range;
-	}
+        return range;
+    }
 };
 
 //Types of heatmaps offered
 static enum HeatmapType
 {
-	Population,
-	Value,
-	Population_Bar,
-	Value_Bar
+    Population,
+    Value,
+    Population_Bar,
+    Value_Bar
 };
 
 static enum AnimationState
 {
-	Stopped,
-	Playing,
-	Paused,
+    Stopped,
+    Playing,
+    Paused,
 };
 
 struct ColorRange
 {
-	int16 R;
-	int16 G;
-	int16 B;
-	int16 A;
+    int16 R;
+    int16 G;
+    int16 B;
+    int16 A;
 };
 
 //Wraps colors and brushes for heatmap settings
 struct HeatmapColors
 {
 private:
-	FColor lowColor;
-	FSlateBrush lowColorBrush;
-	FColor highColor;
-	FSlateBrush highColorBrush;
-	ColorRange range;
+    FColor lowColor;
+    FSlateBrush lowColorBrush;
+    FColor highColor;
+    FSlateBrush highColorBrush;
+    ColorRange range;
 
-	void UpdateRange()
-	{
-		range.A = highColor.A - lowColor.A;
-		range.B = highColor.B - lowColor.B;
-		range.G = highColor.G - lowColor.G;
-		range.R = highColor.R - lowColor.R;
-	}
+    void UpdateRange()
+    {
+        range.A = highColor.A - lowColor.A;
+        range.B = highColor.B - lowColor.B;
+        range.G = highColor.G - lowColor.G;
+        range.R = highColor.R - lowColor.R;
+    }
 
 public:
-	HeatmapColors() : lowColor(FColor::Green), highColor(FColor::Red), lowColorBrush((FSlateBrush)FSlateColorBrush(FColor::Green)), highColorBrush((FSlateBrush)FSlateColorBrush(FColor::Red))
-	{
-		lowColor.A = 128;
-		highColor.A = 128;
-		UpdateRange();
-	}
+    HeatmapColors() : lowColor(FColor::Green), highColor(FColor::Red), lowColorBrush((FSlateBrush)FSlateColorBrush(FColor::Green)), highColorBrush((FSlateBrush)FSlateColorBrush(FColor::Red))
+    {
+        lowColor.A = 128;
+        highColor.A = 128;
+        UpdateRange();
+    }
 
-	FSlateBrush* GetLowBrush()
-	{
-		return &lowColorBrush;
-	}
+    FSlateBrush* GetLowBrush()
+    {
+        return &lowColorBrush;
+    }
 
-	FSlateBrush* GetHighBrush()
-	{
-		return &highColorBrush;
-	}
+    FSlateBrush* GetHighBrush()
+    {
+        return &highColorBrush;
+    }
 
-	void SetLowColor(FColor inColor)
-	{
-		lowColor = inColor;
-		lowColorBrush = (FSlateBrush)FSlateColorBrush(lowColor);
-		UpdateRange();
-	}
+    void SetLowColor(FColor inColor)
+    {
+        lowColor = inColor;
+        lowColorBrush = (FSlateBrush)FSlateColorBrush(lowColor);
+        UpdateRange();
+    }
 
-	void SetHighColor(FColor inColor)
-	{
-		highColor = inColor;
-		highColorBrush = (FSlateBrush)FSlateColorBrush(highColor);
-		UpdateRange();
-	}
+    void SetHighColor(FColor inColor)
+    {
+        highColor = inColor;
+        highColorBrush = (FSlateBrush)FSlateColorBrush(highColor);
+        UpdateRange();
+    }
 
-	FColor GetLowColor()
-	{
-		return lowColor;
-	}
+    FColor GetLowColor()
+    {
+        return lowColor;
+    }
 
-	FColor GetHighColor()
-	{
-		return highColor;
-	}
+    FColor GetHighColor()
+    {
+        return highColor;
+    }
 
-	FColor GetColorFromRange(float location)
-	{
-		FColor retColor = lowColor;
+    FColor GetColorFromRange(float location)
+    {
+        FColor retColor = lowColor;
 
-		retColor.A += (int16)(range.A * location);
-		retColor.R += (int16)(range.R * location);
-		retColor.G += (int16)(range.G * location);
-		retColor.B += (int16)(range.B * location);
+        retColor.A += (int16)(range.A * location);
+        retColor.R += (int16)(range.R * location);
+        retColor.G += (int16)(range.G * location);
+        retColor.B += (int16)(range.B * location);
 
-		return retColor;
-	}
+        return retColor;
+    }
 };
 
 //Nodes used when preparing a heatmap
 struct HeatmapNode
 {
-	int numValues;
-	int values;
-	FVector orientation;
+    int numValues;
+    double values;
+    FVector orientation;
 
-	HeatmapNode() : numValues(0), values(0), orientation(FVector::ZeroVector) {}
+    HeatmapNode() : numValues(0), values(0), orientation(FVector::ZeroVector) {}
 };
 
 //Strings associated with different viz settings for UI
 static const TArray<FString> ShapeListStrings =
 {
-	"Sphere",
-	"Cone",
-	"Cube",
-	"Cylinder",
-	"Plane"
+    "Sphere",
+    "Cone",
+    "Cube",
+    "Cylinder",
+    "Plane"
 };
 
 static const TArray<FString> HeatmapTypeStrings =
 {
-	"Population",
-	"Value",
-	"Population - Bar",
-	"Value - Bar"
+    "Population",
+    "Value",
+    "Population - Bar",
+    "Value - Bar"
 };
 
 static const TArray<FString> AndOrStrings =
 {
-	"Or",
-	"And"
+    "Or",
+    "And"
 };
 
 static const TArray<FString> QueryFieldStrings =
 {
-	"Category",
-	"Build ID",
-	"Build Type",
-	"Client ID",
-	"Platform",
-	"Process ID",
-	"Session ID",
-	"User ID"
+    "Category",
+    "Build ID",
+    "Build Type",
+    "Client ID",
+    "Platform",
+    "Process ID",
+    "Session ID",
+    "User ID"
 };
 
 static const TArray<FString> QueryExpectedStrings =
 {
-	"cat",
-	"build_id",
-	"build_type",
-	"client_id",
-	"platform",
-	"process_id",
-	"session_id",
-	"user_id"
+    "cat",
+    "build_id",
+    "build_type",
+    "client_id",
+    "platform",
+    "process_id",
+    "session_id",
+    "user_id"
 };
 
 static enum QueryField
 {
-	Category,
-	Build_ID,
-	Build_Type,
-	Client_ID,
-	Platform,
-	Process_ID,
-	Session_ID,
-	User_ID
+    Category,
+    Build_ID,
+    Build_Type,
+    Client_ID,
+    Platform,
+    Process_ID,
+    Session_ID,
+    User_ID
 };
 
 static const TArray<FString> QueryOperatorStrings =
 {
-	"==",
-	"<>",
-	">",
-	"<",
-	">=",
-	"<="
+    "==",
+    "<>",
+    ">",
+    "<",
+    ">=",
+    "<="
 };
 
 static enum QueryOperator
 {
-	Equal,
-	Not_Equal,
-	GreaterThan,
-	LessThan,
-	GreaterThanOrEqual,
-	LessThanOrEqual
+    Equal,
+    Not_Equal,
+    GreaterThan,
+    LessThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual
 };
 
 //Container for each UI line of the query
 struct SQuerySetting
 {
-	bool isAnd;
-	QueryField Field;
-	QueryOperator Operator;
-	FString Value;
+    bool isAnd;
+    QueryField Field;
+    QueryOperator Operator;
+    FString Value;
 
-	SQuerySetting() : isAnd(false), Field(QueryField::Category), Operator(QueryOperator::Equal), Value("")
-	{
-	}
+    SQuerySetting() : isAnd(false), Field(QueryField::Category), Operator(QueryOperator::Equal), Value("")
+    {
+    }
 };
 
 //Manages animation state based on the time an animation was started
 struct AnimationController
 {
 private:
-	AnimationState state;
+    AnimationState state;
 
-	int playSpeed;
-	int nextIndexDraw;
-	bool needRefresh;
+    int playSpeed;
+    int nextIndexDraw;
+    bool needRefresh;
 
-	FDateTime localStartTime;
+    FDateTime localStartTime;
 
-	SEventEditorContainer* eventContainer;
+    SEventEditorContainer* eventContainer;
 
 public:
-	AnimationController()
-	{
-		state = AnimationState::Stopped;
-		playSpeed = 0;
-		nextIndexDraw = 0;
-		needRefresh = true;
-		eventContainer = nullptr;
-	}
+    AnimationController()
+    {
+        state = AnimationState::Stopped;
+        playSpeed = 0;
+        nextIndexDraw = 0;
+        needRefresh = true;
+        eventContainer = nullptr;
+    }
 
-	AnimationController(SEventEditorContainer* newContainer)
-	{
-		state = AnimationState::Stopped;
-		playSpeed = 0;
-		nextIndexDraw = 0;
-		needRefresh = true;
-		eventContainer = newContainer;
-	}
+    AnimationController(SEventEditorContainer* newContainer)
+    {
+        state = AnimationState::Stopped;
+        playSpeed = 0;
+        nextIndexDraw = 0;
+        needRefresh = true;
+        eventContainer = newContainer;
+    }
 
-	bool IsPlaying() { return state == AnimationState::Playing; }
-	bool IsPaused() { return state == AnimationState::Paused; }
-	bool IsStopped() { return state == AnimationState::Stopped; }
+    bool IsPlaying() { return state == AnimationState::Playing; }
+    bool IsPaused() { return state == AnimationState::Paused; }
+    bool IsStopped() { return state == AnimationState::Stopped; }
 
-	SEventEditorContainer* GetEventContainer() { return eventContainer;	}
+    SEventEditorContainer* GetEventContainer() { return eventContainer;	}
 
-	FTimespan GetTimespan()
-	{
-		if (eventContainer != nullptr)
-		{
-			return eventContainer->GetTimespan();
-		}
+    FTimespan GetTimespan()
+    {
+        if (eventContainer != nullptr)
+        {
+            return eventContainer->GetTimespan();
+        }
 
-		return FTimespan(0);
-	}
-			
+        return FTimespan(0);
+    }
+            
 
-	void UpdateContainer(SEventEditorContainer* newContainer) { eventContainer = newContainer; }
+    void UpdateContainer(SEventEditorContainer* newContainer) { eventContainer = newContainer; }
 
-	FColor GetColor()
-	{
-		if (eventContainer != nullptr)
-		{
-			return eventContainer->GetColor();
-		}
+    FColor GetColor()
+    {
+        if (eventContainer != nullptr)
+        {
+            return eventContainer->GetColor();
+        }
 
-		return FColor::Red;
-	}
+        return FColor::Red;
+    }
 
-	EventType GetShapeType()
-	{
-		if (eventContainer != nullptr)
-		{
-			return eventContainer->GetShapeType();
-		}
+    EventType GetShapeType()
+    {
+        if (eventContainer != nullptr)
+        {
+            return eventContainer->GetShapeType();
+        }
 
-		return EventType::Sphere;
-	}
+        return EventType::Sphere;
+    }
 
-	bool NeedRefresh()
-	{
-		bool ret = needRefresh;
-		needRefresh = false;
-		return ret;
-	}
+    bool NeedRefresh()
+    {
+        bool ret = needRefresh;
+        needRefresh = false;
+        return ret;
+    }
 
-	void Play(int speed)
-	{
-		if (eventContainer == nullptr) return;
+    void Play(int speed)
+    {
+        if (eventContainer == nullptr) return;
 
-		if (state == AnimationState::Playing && playSpeed == speed)
-		{
-			//Already playing at this speed, so pause
-			Pause();
-		}
-		else if (state == AnimationState::Playing)
-		{
-			//Need to play at different speed, so reset the start time to when it would have started
-			//at the given speed
-			localStartTime = FDateTime::UtcNow();
+        if (state == AnimationState::Playing && playSpeed == speed)
+        {
+            //Already playing at this speed, so pause
+            Pause();
+        }
+        else if (state == AnimationState::Playing)
+        {
+            //Need to play at different speed, so reset the start time to when it would have started
+            //at the given speed
+            localStartTime = FDateTime::UtcNow();
 
-			if (nextIndexDraw > 0)
-			{
-				localStartTime -= eventContainer->events[nextIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
-			}
-		}
-		else if (state == AnimationState::Stopped)
-		{
-			//Start playing from the beginning
-			needRefresh = true;
+            if (nextIndexDraw > 0)
+            {
+                localStartTime -= eventContainer->events[nextIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
+            }
+        }
+        else if (state == AnimationState::Stopped)
+        {
+            //Start playing from the beginning
+            needRefresh = true;
 
-			if(speed >= 0)
-			{
-				nextIndexDraw = eventContainer->events.Num() - 1;
-			}
-			else
-			{
-				nextIndexDraw = 0;
-			}
+            if(speed >= 0)
+            {
+                nextIndexDraw = eventContainer->events.Num() - 1;
+            }
+            else
+            {
+                nextIndexDraw = 0;
+            }
 
-			localStartTime = FDateTime::UtcNow();
-			state = AnimationState::Playing;
-			eventContainer->SetShouldAnimate(true);
-		}
-		else if (state == AnimationState::Paused)
-		{
-			//Resume playing, so update start time to include the time this was paused
-			localStartTime = FDateTime::UtcNow();
+            localStartTime = FDateTime::UtcNow();
+            state = AnimationState::Playing;
+            eventContainer->SetShouldAnimate(true);
+        }
+        else if (state == AnimationState::Paused)
+        {
+            //Resume playing, so update start time to include the time this was paused
+            localStartTime = FDateTime::UtcNow();
 
-			if (nextIndexDraw > 0)
-			{
-				localStartTime -= eventContainer->events[nextIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
-			}
+            if (nextIndexDraw > 0)
+            {
+                localStartTime -= eventContainer->events[nextIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
+            }
 
-			state = AnimationState::Playing;
-			eventContainer->SetShouldAnimate(true);
-		}
+            state = AnimationState::Playing;
+            eventContainer->SetShouldAnimate(true);
+        }
 
-		playSpeed = speed;
-	}
+        playSpeed = speed;
+    }
 
-	void Pause()
-	{
-		if (eventContainer == nullptr) return;
-		state = AnimationState::Paused;
-		eventContainer->SetShouldAnimate(false);
-	}
+    void Pause()
+    {
+        if (eventContainer == nullptr) return;
+        state = AnimationState::Paused;
+        eventContainer->SetShouldAnimate(false);
+    }
 
-	void Stop()
-	{
-		if (eventContainer == nullptr) return;
-		state = AnimationState::Stopped;
-		playSpeed = 0;
-		nextIndexDraw = eventContainer->events.Num() - 1;
-		eventContainer->SetShouldAnimate(false);
-	}
+    void Stop()
+    {
+        if (eventContainer == nullptr) return;
+        state = AnimationState::Stopped;
+        playSpeed = 0;
+        nextIndexDraw = eventContainer->events.Num() - 1;
+        eventContainer->SetShouldAnimate(false);
+    }
 
-	int GetPlaySpeed() { return playSpeed; }
-	void SetPlaySpeed(int speed) { playSpeed = speed; }
-	bool ShouldAnimate() { return eventContainer->ShouldAnimate(); }
+    int GetPlaySpeed() { return playSpeed; }
+    void SetPlaySpeed(int speed) { playSpeed = speed; }
+    bool ShouldAnimate() { return eventContainer->ShouldAnimate(); }
 
-	int GetNextIndex() { return nextIndexDraw; }
-	int GetPrevIndex()
-	{
-		if (nextIndexDraw <= 0)
-		{
-			return eventContainer->events.Num() - 1;
-		}
+    int GetNextIndex() { return nextIndexDraw; }
+    int GetPrevIndex()
+    {
+        if (nextIndexDraw <= 0)
+        {
+            return eventContainer->events.Num() - 1;
+        }
 
-		return nextIndexDraw - 1;
-	}
+        return nextIndexDraw - 1;
+    }
 
-	//Provides an array of pointers to events that are ready to draw for the animation
-	TArray<TSharedPtr<STelemetryEvent>> GetNextEvents()
-	{
-		if (nextIndexDraw <= 0)
-		{
-			Stop();
-			eventContainer->SetShouldDraw(true);
-		}
+    //Provides an array of pointers to events that are ready to draw for the animation
+    TArray<TSharedPtr<STelemetryEvent>> GetNextEvents()
+    {
+        if (nextIndexDraw <= 0)
+        {
+            Stop();
+            eventContainer->SetShouldDraw(true);
+        }
 
-		TArray<TSharedPtr<STelemetryEvent>> newArray;
+        TArray<TSharedPtr<STelemetryEvent>> newArray;
 
-		if (playSpeed >= 0)
-		{
-			FDateTime tempTime = eventContainer->events[eventContainer->events.Num() - 1]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
+        if (playSpeed >= 0)
+        {
+            FDateTime tempTime = eventContainer->events[eventContainer->events.Num() - 1]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
 
-			while (nextIndexDraw >= 0 && eventContainer->events[nextIndexDraw]->time < tempTime)
-			{
-				newArray.Add(eventContainer->events[nextIndexDraw]);
-				nextIndexDraw--;
-			}
+            while (nextIndexDraw >= 0 && eventContainer->events[nextIndexDraw]->time < tempTime)
+            {
+                newArray.Add(eventContainer->events[nextIndexDraw]);
+                nextIndexDraw--;
+            }
 
-			if (newArray.Num() == 0 && nextIndexDraw >= 0)
-			{
-				//Skip ahead if the gap between events is too long
-				FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
-				if (timeToNext > FTimespan(0, 0, 30))
-				{
-					localStartTime -= timeToNext - FTimespan(0, 0, 5);
-				}
-			}
-		}
+            if (newArray.Num() == 0 && nextIndexDraw >= 0)
+            {
+                //Skip ahead if the gap between events is too long
+                FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
+                if (timeToNext > FTimespan(0, 0, 30))
+                {
+                    localStartTime -= timeToNext - FTimespan(0, 0, 5);
+                }
+            }
+        }
 
-		return newArray;
-	}
+        return newArray;
+    }
 
-	//Provides the index of the next event to draw
-	int GetNextEventCount()
-	{
-		if (nextIndexDraw <= 0)
-		{
-			Stop();
-			//eventContainer->SetShouldDraw(true);
-		}
+    //Provides the index of the next event to draw
+    int GetNextEventCount()
+    {
+        if (nextIndexDraw <= 0)
+        {
+            Stop();
+            //eventContainer->SetShouldDraw(true);
+        }
 
-		bool newEvents = false;
+        bool newEvents = false;
 
-		if (playSpeed >= 0)
-		{
-			FDateTime tempTime = eventContainer->events[eventContainer->events.Num() - 1]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
+        if (playSpeed >= 0)
+        {
+            FDateTime tempTime = eventContainer->events[eventContainer->events.Num() - 1]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
 
-			while (nextIndexDraw >= 0 && eventContainer->events[nextIndexDraw]->time < tempTime)
-			{
-				newEvents = true;
-				nextIndexDraw--;
-			}
+            while (nextIndexDraw >= 0 && eventContainer->events[nextIndexDraw]->time < tempTime)
+            {
+                newEvents = true;
+                nextIndexDraw--;
+            }
 
-			if (!newEvents && nextIndexDraw >= 0)
-			{
-				//Skip ahead if the gap between events is too long
-				FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
-				if (timeToNext > FTimespan(0, 0, 30))
-				{
-					localStartTime -= timeToNext - FTimespan(0, 0, 5);
-				}
-			}
+            if (!newEvents && nextIndexDraw >= 0)
+            {
+                //Skip ahead if the gap between events is too long
+                FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
+                if (timeToNext > FTimespan(0, 0, 30))
+                {
+                    localStartTime -= timeToNext - FTimespan(0, 0, 5);
+                }
+            }
 
-			if (nextIndexDraw < 0)
-			{
-				nextIndexDraw = 0;
-			}
-		}
+            if (nextIndexDraw < 0)
+            {
+                nextIndexDraw = 0;
+            }
+        }
 
-		return nextIndexDraw;
-	}
+        return nextIndexDraw;
+    }
 
-	//Provides an array of pointers to events that are ready to draw for the animation (in reverse)
-	TArray<TSharedPtr<STelemetryEvent>> GetPrevEvents()
-	{
-		TArray<TSharedPtr<STelemetryEvent>> newArray;
+    //Provides an array of pointers to events that are ready to draw for the animation (in reverse)
+    TArray<TSharedPtr<STelemetryEvent>> GetPrevEvents()
+    {
+        TArray<TSharedPtr<STelemetryEvent>> newArray;
 
-		if (playSpeed < 0)
-		{
-			if (nextIndexDraw >= eventContainer->events.Num() - 1)
-			{
-				Stop();
-				eventContainer->SetShouldDraw(false);
-			}
+        if (playSpeed < 0)
+        {
+            if (nextIndexDraw >= eventContainer->events.Num() - 1)
+            {
+                Stop();
+                eventContainer->SetShouldDraw(false);
+            }
 
-			FDateTime tempTime = eventContainer->events[0]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
+            FDateTime tempTime = eventContainer->events[0]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
 
-			while (nextIndexDraw < eventContainer->events.Num() && eventContainer->events[nextIndexDraw]->time > tempTime)
-			{
-				newArray.Add(eventContainer->events[nextIndexDraw]);
-				nextIndexDraw++;
-			}
+            while (nextIndexDraw < eventContainer->events.Num() && eventContainer->events[nextIndexDraw]->time > tempTime)
+            {
+                newArray.Add(eventContainer->events[nextIndexDraw]);
+                nextIndexDraw++;
+            }
 
-			if (newArray.Num() == 0 && nextIndexDraw < eventContainer->events.Num())
-			{
-				//Skip ahead if the gap between events is too long
-				FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
-				if (timeToNext > FTimespan(0, 0, 30))
-				{
-					localStartTime += timeToNext - FTimespan(0, 0, 5);
-				}
-			}
-		}
+            if (newArray.Num() == 0 && nextIndexDraw < eventContainer->events.Num())
+            {
+                //Skip ahead if the gap between events is too long
+                FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
+                if (timeToNext > FTimespan(0, 0, 30))
+                {
+                    localStartTime += timeToNext - FTimespan(0, 0, 5);
+                }
+            }
+        }
 
-		return newArray;
-	}
+        return newArray;
+    }
 
-	//Provides the index of the next event to draw (in reverse)
-	int GetPrevEventCount()
-	{
-		if (playSpeed < 0)
-		{
-			if (nextIndexDraw >= eventContainer->events.Num() - 1)
-			{
-				Stop();
-				//eventContainer->SetShouldDraw(false);
-			}
+    //Provides the index of the next event to draw (in reverse)
+    int GetPrevEventCount()
+    {
+        if (playSpeed < 0)
+        {
+            if (nextIndexDraw >= eventContainer->events.Num() - 1)
+            {
+                Stop();
+                //eventContainer->SetShouldDraw(false);
+            }
 
-			FDateTime tempTime = eventContainer->events[0]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
-			bool newEvents = false;
+            FDateTime tempTime = eventContainer->events[0]->time + ((FDateTime::UtcNow() - localStartTime) * playSpeed);
+            bool newEvents = false;
 
-			while (nextIndexDraw < eventContainer->events.Num() && eventContainer->events[nextIndexDraw]->time > tempTime)
-			{
-				newEvents = true;
-				nextIndexDraw++;
-			}
+            while (nextIndexDraw < eventContainer->events.Num() && eventContainer->events[nextIndexDraw]->time > tempTime)
+            {
+                newEvents = true;
+                nextIndexDraw++;
+            }
 
-			if (!newEvents && nextIndexDraw < eventContainer->events.Num())
-			{
-				//Skip ahead if the gap between events is too long
-				FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
-				if (timeToNext > FTimespan(0, 0, 30))
-				{
-					localStartTime += timeToNext - FTimespan(0, 0, 5);
-				}
-			}
+            if (!newEvents && nextIndexDraw < eventContainer->events.Num())
+            {
+                //Skip ahead if the gap between events is too long
+                FTimespan timeToNext = eventContainer->events[nextIndexDraw]->time - tempTime;
+                if (timeToNext > FTimespan(0, 0, 30))
+                {
+                    localStartTime += timeToNext - FTimespan(0, 0, 5);
+                }
+            }
 
-			if (nextIndexDraw >= eventContainer->events.Num())
-			{
-				nextIndexDraw = eventContainer->events.Num() - 1;
-			}
-		}
+            if (nextIndexDraw >= eventContainer->events.Num())
+            {
+                nextIndexDraw = eventContainer->events.Num() - 1;
+            }
+        }
 
-		return nextIndexDraw;
-	}
+        return nextIndexDraw;
+    }
 
-	//Set a time for playback  (0 to 1)
-	void SetPlaybackTime(float scale)
-	{
-		if (eventContainer == nullptr) return;
+    //Set a time for playback  (0 to 1)
+    void SetPlaybackTime(float scale)
+    {
+        if (eventContainer == nullptr) return;
 
-		int newIndexDraw = GetEventIndexForTimeScale(scale);
+        int newIndexDraw = GetEventIndexForTimeScale(scale);
 
-		localStartTime = FDateTime::UtcNow();
+        localStartTime = FDateTime::UtcNow();
 
-		if (newIndexDraw > 0 && newIndexDraw < eventContainer->events.Num() - 1)
-		{
-			localStartTime -= eventContainer->events[newIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
-		}
+        if (newIndexDraw > 0 && newIndexDraw < eventContainer->events.Num() - 1)
+        {
+            localStartTime -= eventContainer->events[newIndexDraw]->time - eventContainer->events[eventContainer->events.Num() - 1]->time;
+        }
 
-		needRefresh = true;
-	}
+        needRefresh = true;
+    }
 
-	FTimespan GetCurrentPlayTime()
-	{
-		if (playSpeed >= 0)
-		{
-			return (FDateTime::UtcNow() - localStartTime) * playSpeed;
-		}
-		else
-		{
-			return eventContainer->GetTimespan() + (FDateTime::UtcNow() - localStartTime) * playSpeed;
-		}
-	}
+    FTimespan GetCurrentPlayTime()
+    {
+        if (playSpeed >= 0)
+        {
+            return (FDateTime::UtcNow() - localStartTime) * playSpeed;
+        }
+        else
+        {
+            return eventContainer->GetTimespan() + (FDateTime::UtcNow() - localStartTime) * playSpeed;
+        }
+    }
 
-	float GetTimeScaleFromTime()
-	{
-		return eventContainer->GetTimeScaleFromTime((FDateTime::UtcNow() - localStartTime) * playSpeed);
-	}
+    float GetTimeScaleFromTime()
+    {
+        return eventContainer->GetTimeScaleFromTime((FDateTime::UtcNow() - localStartTime) * playSpeed);
+    }
 
-	float GetEventTimeScale(int i)
-	{
-		return eventContainer->GetEventTimeScale(i);
-	}
+    float GetEventTimeScale(int i)
+    {
+        return eventContainer->GetEventTimeScale(i);
+    }
 
-	int GetEventIndexForTimeScale(float scale)
-	{
-		return eventContainer->GetEventIndexForTimeScale(scale);
-	}
+    int GetEventIndexForTimeScale(float scale)
+    {
+        return eventContainer->GetEventIndexForTimeScale(scale);
+    }
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
@@ -23,515 +23,515 @@
 
 void FTelemetryVisualizerUI::Initialize()
 {
-	//Editor states
-	m_editorDrawTarget = nullptr;
-	m_gameDrawTarget = nullptr;
-	m_PIEDrawTarget = nullptr;
-	m_registeredWidget = false;
-	m_needsActorUpdate = true;
+    //Editor states
+    m_editorDrawTarget = nullptr;
+    m_gameDrawTarget = nullptr;
+    m_PIEDrawTarget = nullptr;
+    m_registeredWidget = false;
+    m_needsActorUpdate = true;
 
-	//Default event list
-	m_anim_scrollBarLocation = 0.f;
-	m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
-	m_vizSelection = m_eventgroupList[0];
-	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
-	m_subVizSelection = m_eventgroupSubList[0];
+    //Default event list
+    m_anim_scrollBarLocation = 0.f;
+    m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
+    m_vizSelection = m_eventgroupList[0];
+    m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+    m_subVizSelection = m_eventgroupSubList[0];
 
-	//Default heatmap state
-	m_heatmapType = HeatmapType::Population;
-	m_heatmapSize = MinHeatmapSize * 4;
-	m_heatmapShapeType = EventType::Cube;
-	m_material = nullptr;
-	m_heatmapMinValue = -1;
-	m_heatmapMaxValue = -1;
-	m_heatmapOrientation = false;
-	m_heatmapAnimation = false;
+    //Default heatmap state
+    m_heatmapType = HeatmapType::Population;
+    m_heatmapSize = MinHeatmapSize * 4;
+    m_heatmapShapeType = EventType::Cube;
+    m_material = nullptr;
+    m_heatmapMinValue = -1;
+    m_heatmapMaxValue = -1;
+    m_heatmapOrientation = false;
+    m_heatmapAnimation = false;
 
-	//Default list of render shapes
-	for (int i = 0; i < ShapeListStrings.Num(); i++)
-	{
-		m_shapeList.Add(MakeShareable<FString>(new FString(ShapeListStrings[i])));
-	}
+    //Default list of render shapes
+    for (int i = 0; i < ShapeListStrings.Num(); i++)
+    {
+        m_shapeList.Add(MakeShareable<FString>(new FString(ShapeListStrings[i])));
+    }
 
-	//Default list of heatmap types
-	for (int i = 0; i < HeatmapTypeStrings.Num(); i++)
-	{
-		m_heatmapTypeList.Add(MakeShareable<FString>(new FString(HeatmapTypeStrings[i])));
-	}
+    //Default list of heatmap types
+    for (int i = 0; i < HeatmapTypeStrings.Num(); i++)
+    {
+        m_heatmapTypeList.Add(MakeShareable<FString>(new FString(HeatmapTypeStrings[i])));
+    }
 
-	//Default list of query fields
-	for (int i = 0; i < QueryFieldStrings.Num(); i++)
-	{
-		m_queryFieldList.Add(MakeShareable<FString>(new FString(QueryFieldStrings[i])));
-	}
+    //Default list of query fields
+    for (int i = 0; i < QueryFieldStrings.Num(); i++)
+    {
+        m_queryFieldList.Add(MakeShareable<FString>(new FString(QueryFieldStrings[i])));
+    }
 
-	//Default list of query operators
-	for (int i = 0; i < QueryOperatorStrings.Num(); i++)
-	{
-		m_queryOperatorList.Add(MakeShareable<FString>(new FString(QueryOperatorStrings[i])));
-	}
+    //Default list of query operators
+    for (int i = 0; i < QueryOperatorStrings.Num(); i++)
+    {
+        m_queryOperatorList.Add(MakeShareable<FString>(new FString(QueryOperatorStrings[i])));
+    }
 
-	//Default list of query and/or
-	for (int i = 0; i < AndOrStrings.Num(); i++)
-	{
-		m_queryAndOrList.Add(MakeShareable<FString>(new FString(AndOrStrings[i])));
-	}
+    //Default list of query and/or
+    for (int i = 0; i < AndOrStrings.Num(); i++)
+    {
+        m_queryAndOrList.Add(MakeShareable<FString>(new FString(AndOrStrings[i])));
+    }
 
-	//Add required default query condition
-	AddClause(-1);
+    //Add required default query condition
+    AddClause(-1);
 
-	//Add tab spawner
-	TSharedPtr<FWorkspaceItem> WorkspaceMenuCategory = FGlobalTabmanager::Get()->AddLocalWorkspaceMenuCategory(LOCTEXT("Telemetry_Telemetry", "Telemetry"));
-	auto WorkspaceMenuCategoryRef = WorkspaceMenuCategory.ToSharedRef();
+    //Add tab spawner
+    TSharedPtr<FWorkspaceItem> WorkspaceMenuCategory = FGlobalTabmanager::Get()->AddLocalWorkspaceMenuCategory(LOCTEXT("Telemetry_Telemetry", "Telemetry"));
+    auto WorkspaceMenuCategoryRef = WorkspaceMenuCategory.ToSharedRef();
 
-	FGlobalTabmanager::Get()->RegisterTabSpawner(TelemetryDataIndirectTabName, FOnSpawnTab::CreateRaw(this, &FTelemetryVisualizerUI::SpawnDataTab))
-		.SetGroup(WorkspaceMenuCategoryRef)
-		.SetDisplayName(FText::FromString(TEXT("Telemetry Data Viewer")));
+    FGlobalTabmanager::Get()->RegisterTabSpawner(TelemetryDataIndirectTabName, FOnSpawnTab::CreateRaw(this, &FTelemetryVisualizerUI::SpawnDataTab))
+        .SetGroup(WorkspaceMenuCategoryRef)
+        .SetDisplayName(FText::FromString(TEXT("Telemetry Data Viewer")));
 
-	FGlobalTabmanager::Get()->RegisterTabSpawner(TelemetryVizIndirectTabName, FOnSpawnTab::CreateRaw(this, &FTelemetryVisualizerUI::SpawnVizTab))
-		.SetGroup(WorkspaceMenuCategoryRef)
-		.SetDisplayName(FText::FromString(TEXT("Telemetry Visualization Tools")));
+    FGlobalTabmanager::Get()->RegisterTabSpawner(TelemetryVizIndirectTabName, FOnSpawnTab::CreateRaw(this, &FTelemetryVisualizerUI::SpawnVizTab))
+        .SetGroup(WorkspaceMenuCategoryRef)
+        .SetDisplayName(FText::FromString(TEXT("Telemetry Visualization Tools")));
 
-	//Add editor UI extensions
-	if (!IsRunningCommandlet() && !IsRunningGame())
-	{
-		TelemetryVisualizerCommands::Register();
+    //Add editor UI extensions
+    if (!IsRunningCommandlet() && !IsRunningGame())
+    {
+        TelemetryVisualizerCommands::Register();
 
-		m_pluginCommands = MakeShareable(new FUICommandList);
+        m_pluginCommands = MakeShareable(new FUICommandList);
 
-		m_pluginCommands->MapAction(
-			TelemetryVisualizerCommands::Get().m_displayDataTab,
-			FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowDataTab),
-			FCanExecuteAction());
+        m_pluginCommands->MapAction(
+            TelemetryVisualizerCommands::Get().m_displayDataTab,
+            FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowDataTab),
+            FCanExecuteAction());
 
-		m_pluginCommands->MapAction(
-			TelemetryVisualizerCommands::Get().m_displayVizTab,
-			FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowVizTab),
-			FCanExecuteAction());
+        m_pluginCommands->MapAction(
+            TelemetryVisualizerCommands::Get().m_displayVizTab,
+            FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowVizTab),
+            FCanExecuteAction());
 
-		m_pluginCommands->MapAction(
-			TelemetryVisualizerCommands::Get().m_displayAll,
-			FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowAll),
-			FCanExecuteAction());
+        m_pluginCommands->MapAction(
+            TelemetryVisualizerCommands::Get().m_displayAll,
+            FExecuteAction::CreateRaw(this, &FTelemetryVisualizerUI::ShowAll),
+            FCanExecuteAction());
 
-		m_menuExtender = MakeShareable(new FExtender);
-		m_menuExtension = m_menuExtender->AddMenuExtension("General", EExtensionHook::After, m_pluginCommands, FMenuExtensionDelegate::CreateRaw(this, &FTelemetryVisualizerUI::AddMenuExtensions));
+        m_menuExtender = MakeShareable(new FExtender);
+        m_menuExtension = m_menuExtender->AddMenuExtension("General", EExtensionHook::After, m_pluginCommands, FMenuExtensionDelegate::CreateRaw(this, &FTelemetryVisualizerUI::AddMenuExtensions));
 
-		FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-		LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(m_menuExtender);
+        FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+        LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(m_menuExtender);
 
-		m_extensionManager = LevelEditorModule.GetMenuExtensibilityManager();
-	}
+        m_extensionManager = LevelEditorModule.GetMenuExtensibilityManager();
+    }
 
-	//Setup timer
-	m_tickDelegateHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &FTelemetryVisualizerUI::UpdateDraw));
-	m_startPIEDelegateHandle = FEditorDelegates::PostPIEStarted.AddRaw(this, &FTelemetryVisualizerUI::PIEStarted);
-	m_endPIEDelegateHandle = FEditorDelegates::EndPIE.AddRaw(this, &FTelemetryVisualizerUI::PIEEnded);
+    //Setup timer
+    m_tickDelegateHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &FTelemetryVisualizerUI::UpdateDraw));
+    m_startPIEDelegateHandle = FEditorDelegates::PostPIEStarted.AddRaw(this, &FTelemetryVisualizerUI::PIEStarted);
+    m_endPIEDelegateHandle = FEditorDelegates::EndPIE.AddRaw(this, &FTelemetryVisualizerUI::PIEEnded);
 }
 
 void FTelemetryVisualizerUI::Shutdown()
 {
-	FTicker::GetCoreTicker().RemoveTicker(m_tickDelegateHandle);
-	FEditorDelegates::PostPIEStarted.Remove(m_startPIEDelegateHandle);
-	FEditorDelegates::PostPIEStarted.Remove(m_endPIEDelegateHandle);
+    FTicker::GetCoreTicker().RemoveTicker(m_tickDelegateHandle);
+    FEditorDelegates::PostPIEStarted.Remove(m_startPIEDelegateHandle);
+    FEditorDelegates::PostPIEStarted.Remove(m_endPIEDelegateHandle);
 
-	FGlobalTabmanager::Get()->UnregisterTabSpawner(TelemetryDataIndirectTabName);
-	FGlobalTabmanager::Get()->UnregisterTabSpawner(TelemetryVizIndirectTabName);
-	
-	//Remove editor UI extensions
-	if (m_extensionManager.IsValid())
-	{
-		TelemetryVisualizerCommands::Unregister();
+    FGlobalTabmanager::Get()->UnregisterTabSpawner(TelemetryDataIndirectTabName);
+    FGlobalTabmanager::Get()->UnregisterTabSpawner(TelemetryVizIndirectTabName);
+    
+    //Remove editor UI extensions
+    if (m_extensionManager.IsValid())
+    {
+        TelemetryVisualizerCommands::Unregister();
 
-		m_menuExtender->RemoveExtension(m_menuExtension.ToSharedRef());
+        m_menuExtender->RemoveExtension(m_menuExtension.ToSharedRef());
 
-		m_extensionManager->RemoveExtender(m_menuExtender);
-	}
-	else
-	{
-		m_extensionManager.Reset();
-	}
+        m_extensionManager->RemoveExtender(m_menuExtender);
+    }
+    else
+    {
+        m_extensionManager.Reset();
+    }
 }
 
 void FTelemetryVisualizerUI::AddMenuExtensions(FMenuBuilder &builder)
 {
-	//Add editor UI elements
-	builder.BeginSection("Telemetry Settings", LOCTEXT("Telemetry Settings", "Telemetry Settings"));
-	builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayDataTab);
-	builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayVizTab);
-	builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayAll);
-	builder.EndSection();
+    //Add editor UI elements
+    builder.BeginSection("Telemetry Settings", LOCTEXT("Telemetry Settings", "Telemetry Settings"));
+    builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayDataTab);
+    builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayVizTab);
+    builder.AddMenuEntry(TelemetryVisualizerCommands::Get().m_displayAll);
+    builder.EndSection();
 }
 
 TSharedRef<SWidget> FTelemetryVisualizerUI::MakeWidgetForOption(TSharedPtr<FString> InOption)
 {
-	return SNew(STextBlock).Text(FText::FromString(*InOption));
+    return SNew(STextBlock).Text(FText::FromString(*InOption));
 }
 
 /////////////////////////////////DRAW TO WORLD/////////////////////////////////
 UWorld* FTelemetryVisualizerUI::GetLocalWorld()
 {
-	UWorld* foundWorld = nullptr;
+    UWorld* foundWorld = nullptr;
 
-	if (m_gameDrawTarget)
-	{
-		foundWorld = m_gameDrawTarget;
-	}
-	else if (m_PIEDrawTarget)
-	{
-		foundWorld = m_PIEDrawTarget;
-	}
-	else if (m_editorDrawTarget)
-	{
-		foundWorld = m_editorDrawTarget;
-	}
+    if (m_gameDrawTarget)
+    {
+        foundWorld = m_gameDrawTarget;
+    }
+    else if (m_PIEDrawTarget)
+    {
+        foundWorld = m_PIEDrawTarget;
+    }
+    else if (m_editorDrawTarget)
+    {
+        foundWorld = m_editorDrawTarget;
+    }
 
-	return foundWorld;
+    return foundWorld;
 }
 
 bool FTelemetryVisualizerUI::UpdateDraw(float val)
 {
-	UWorld* currentTarget = GetLocalWorld();
+    UWorld* currentTarget = GetLocalWorld();
 
-	if (currentTarget == nullptr)
-	{
-		UpdateGameState(true);
-	}
+    if (currentTarget == nullptr)
+    {
+        UpdateGameState(true);
+    }
 
-	if (currentTarget && m_filterCollection.Num() > 0)
-	{
-		DrawTelemetry(currentTarget, m_filterCollection);
-	}
+    if (currentTarget && m_filterCollection.Num() > 0)
+    {
+        DrawTelemetry(currentTarget, m_filterCollection);
+    }
 
-	return true;
+    return true;
 }
 
 void FTelemetryVisualizerUI::UpdateGameState(bool allowPIE)
 {
-	UWorld* currentTarget = nullptr;
-	TIndirectArray<FWorldContext> worldContexts = GEngine->GetWorldContexts();
+    UWorld* currentTarget = nullptr;
+    TIndirectArray<FWorldContext> worldContexts = GEngine->GetWorldContexts();
 
-	m_editorDrawTarget = nullptr;
-	m_gameDrawTarget = nullptr;
-	m_PIEDrawTarget = nullptr;
+    m_editorDrawTarget = nullptr;
+    m_gameDrawTarget = nullptr;
+    m_PIEDrawTarget = nullptr;
 
-	for (int i = 0; i < worldContexts.Num(); i++)
-	{
-		currentTarget = worldContexts[i].World();
+    for (int i = 0; i < worldContexts.Num(); i++)
+    {
+        currentTarget = worldContexts[i].World();
 
-		if (currentTarget)
-		{
-			switch (currentTarget->WorldType)
-			{
-			case EWorldType::PIE:
-				if (allowPIE) m_PIEDrawTarget = currentTarget;
-				break;
-			case EWorldType::Editor:
-				m_editorDrawTarget = currentTarget;
-				break;
-			case EWorldType::Game:
-				m_gameDrawTarget = currentTarget;
-				break;
-			}
-		}
-	}
+        if (currentTarget)
+        {
+            switch (currentTarget->WorldType)
+            {
+            case EWorldType::PIE:
+                if (allowPIE) m_PIEDrawTarget = currentTarget;
+                break;
+            case EWorldType::Editor:
+                m_editorDrawTarget = currentTarget;
+                break;
+            case EWorldType::Game:
+                m_gameDrawTarget = currentTarget;
+                break;
+            }
+        }
+    }
 }
 
 void FTelemetryVisualizerUI::CreateActor(UWorld* drawTarget, int index, TSharedPtr<STelemetryEvent> data, FColor color, EventType shape)
 {
-	ATelemetryEvent* tempActor;
-	FString tempName;
+    ATelemetryEvent* tempActor;
+    FString tempName;
 
-	tempName = data->name + FString::FromInt(index);
+    tempName = data->eventname + FString::FromInt(index);
 
-	FActorSpawnParameters params;
-	params.Name = *tempName;
+    FActorSpawnParameters params;
+    params.Name = *tempName;
 
-	FRotator tempRot = FRotator::ZeroRotator;
-	if (data->orientation != FVector::ZeroVector)
-	{
-		tempRot = data->orientation.Rotation();
-	}
+    FRotator tempRot = FRotator::ZeroRotator;
+    if (data->orientation != FVector::ZeroVector)
+    {
+        tempRot = data->orientation.Rotation();
+    }
 
-	tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data->point, tempRot, params);
-	tempActor->SetActorLabel(*tempName);
+    tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data->point, tempRot, params);
+    tempActor->SetActorLabel(*tempName);
 
-	tempActor->AddEvent(data->point, data->orientation, color, shape);
-	tempActor->SetEvent(data);
+    tempActor->AddEvent(data->point, data->orientation, color, shape);
+    tempActor->SetEvent(data);
 
-	tempName = "/TelemetryEvents/" + FString(data->name);
-	tempActor->SetFolderPath(*tempName);
+    tempName = "/TelemetryEvents/" + FString(data->eventname);
+    tempActor->SetFolderPath(*tempName);
 
-	m_eventActors.Add(tempActor);
+    m_eventActors.Add(tempActor);
 }
 
 void FTelemetryVisualizerUI::CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color, EventType shape)
 {
-	ATelemetryEvent* tempActor;
-	FString tempName;
+    ATelemetryEvent* tempActor;
+    FString tempName;
 
-	for (int i = 0; i < data.Num(); i++)
-	{
-		tempName = data[i]->name + FString::FromInt(i);
+    for (int i = 0; i < data.Num(); i++)
+    {
+        tempName = data[i]->eventname + FString::FromInt(i);
 
-		FActorSpawnParameters params;
-		params.Name = *tempName;
+        FActorSpawnParameters params;
+        params.Name = *tempName;
 
-		FRotator tempRot = FRotator::ZeroRotator;
-		if (data[i]->orientation != FVector::ZeroVector)
-		{
-			tempRot = data[i]->orientation.Rotation();
-		}
+        FRotator tempRot = FRotator::ZeroRotator;
+        if (data[i]->orientation != FVector::ZeroVector)
+        {
+            tempRot = data[i]->orientation.Rotation();
+        }
 
-		tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data[i]->point, tempRot, params);
-		tempActor->SetActorLabel(*tempName);
+        tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data[i]->point, tempRot, params);
+        tempActor->SetActorLabel(*tempName);
 
-		tempActor->AddEvent(data[i]->point, data[i]->orientation, color, shape);
-		tempActor->SetEvent(data[i]);
+        tempActor->AddEvent(data[i]->point, data[i]->orientation, color, shape);
+        tempActor->SetEvent(data[i]);
 
-		tempName = "/TelemetryEvents/" + FString(data[i]->name);
-		tempActor->SetFolderPath(*tempName);
+        tempName = "/TelemetryEvents/" + FString(data[i]->eventname);
+        tempActor->SetFolderPath(*tempName);
 
-		m_eventActors.Add(tempActor);
-	}
+        m_eventActors.Add(tempActor);
+    }
 }
 
 void FTelemetryVisualizerUI::CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color, EventType shape)
 {
-	ATelemetryEvent* tempActor;
-	FString tempName;
+    ATelemetryEvent* tempActor;
+    FString tempName;
 
-	for (int i = start; i < end; i++)
-	{
-		tempName = data[i]->name + FString::FromInt(i);
+    for (int i = start; i < end; i++)
+    {
+        tempName = data[i]->eventname + FString::FromInt(i);
 
-		FActorSpawnParameters params;
-		params.Name = *tempName;
+        FActorSpawnParameters params;
+        params.Name = *tempName;
 
-		tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data[i]->point, FRotator::ZeroRotator, params);
-		tempActor->SetActorLabel(*tempName);
+        tempActor = drawTarget->SpawnActor<ATelemetryEvent>(data[i]->point, FRotator::ZeroRotator, params);
+        tempActor->SetActorLabel(*tempName);
 
-		tempActor->AddEvent(data[i]->point, data[i]->orientation, color, shape);
-		tempActor->SetEvent(data[i]);
+        tempActor->AddEvent(data[i]->point, data[i]->orientation, color, shape);
+        tempActor->SetEvent(data[i]);
 
-		tempName = "/TelemetryEvents/" + FString(data[i]->name);
-		tempActor->SetFolderPath(*tempName);
+        tempName = "/TelemetryEvents/" + FString(data[i]->eventname);
+        tempActor->SetFolderPath(*tempName);
 
-		m_eventActors.Add(tempActor);
-	}
+        m_eventActors.Add(tempActor);
+    }
 }
 
 void FTelemetryVisualizerUI::DestroyActors()
 {
-	UWorld* currentWorld = GetLocalWorld();
+    UWorld* currentWorld = GetLocalWorld();
 
-	if (currentWorld != nullptr)
-	{
-		for (int i = 0; i < m_eventActors.Num(); i++)
-		{
-			currentWorld->DestroyActor(m_eventActors[i]);
-		}
-	}
+    if (currentWorld != nullptr)
+    {
+        for (int i = 0; i < m_eventActors.Num(); i++)
+        {
+            currentWorld->DestroyActor(m_eventActors[i]);
+        }
+    }
 
-	m_eventActors.Empty();
+    m_eventActors.Empty();
 }
 
 void FTelemetryVisualizerUI::DestroyLastActor()
 {
-	UWorld* currentWorld = GetLocalWorld();
+    UWorld* currentWorld = GetLocalWorld();
 
-	if (currentWorld != nullptr && m_eventActors.Num() > 0)
-	{
-		currentWorld->DestroyActor(m_eventActors.Last());
-		m_eventActors.RemoveAt(m_eventActors.Num() - 1);
-	}
+    if (currentWorld != nullptr && m_eventActors.Num() > 0)
+    {
+        currentWorld->DestroyActor(m_eventActors.Last());
+        m_eventActors.RemoveAt(m_eventActors.Num() - 1);
+    }
 }
 
 void FTelemetryVisualizerUI::DrawPoint(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color)
 {
-	DrawDebugPoint(drawTarget, data->point, 5.f, color, true);
+    DrawDebugPoint(drawTarget, data->point, 5.f, color, true);
 }
 
 void FTelemetryVisualizerUI::DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color)
 {
-	DrawPoints(drawTarget, data, 0, data.Num(), color);
+    DrawPoints(drawTarget, data, 0, data.Num(), color);
 }
 
 void FTelemetryVisualizerUI::DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color)
 {
-	for (int i = start; i < end; i++)
-	{
-		DrawPoint(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
-	}
+    for (int i = start; i < end; i++)
+    {
+        DrawPoint(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
+    }
 }
 
 void FTelemetryVisualizerUI::DrawSphere(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color)
 {
-	DrawDebugSphere(drawTarget, data->point, 26.f, 12, color, true);
+    DrawDebugSphere(drawTarget, data->point, 26.f, 12, color, true);
 }
 
 void FTelemetryVisualizerUI::DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color)
 {
-	DrawSpheres(drawTarget, data, 0, data.Num(), color);
+    DrawSpheres(drawTarget, data, 0, data.Num(), color);
 }
 
 void FTelemetryVisualizerUI::DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color)
 {
-	for (int i = start; i < end; i++)
-	{
-		DrawSphere(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
-	}
+    for (int i = start; i < end; i++)
+    {
+        DrawSphere(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
+    }
 }
 
 void FTelemetryVisualizerUI::DrawCube(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color)
 {
-	DrawDebugBox(drawTarget, data->point, FVector(5.f, 5.f, 5.f), color, true);
+    DrawDebugBox(drawTarget, data->point, FVector(5.f, 5.f, 5.f), color, true);
 }
 
 void FTelemetryVisualizerUI::DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color)
 {
-	DrawCubes(drawTarget, data, 0, data.Num(), color);
+    DrawCubes(drawTarget, data, 0, data.Num(), color);
 }
 
 void FTelemetryVisualizerUI::DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color)
 {
-	for (int i = start; i < end; i++)
-	{
-		DrawCube(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
-	}
+    for (int i = start; i < end; i++)
+    {
+        DrawCube(drawTarget, (TSharedPtr<STelemetryEvent>)data[i], color);
+    }
 }
 
 void FTelemetryVisualizerUI::DrawTelemetry(UWorld* drawTarget, TArray<SEventEditorContainer*> data)
 {
-	if (!m_anim_Control.IsStopped())
-	{
-		if (m_anim_Control.ShouldAnimate())
-		{
-			if (m_anim_Control.NeedRefresh())
-			{
-				DestroyActors();
+    if (!m_anim_Control.IsStopped())
+    {
+        if (m_anim_Control.ShouldAnimate())
+        {
+            if (m_anim_Control.NeedRefresh())
+            {
+                DestroyActors();
 
-				//If we are playing in reverse, we need to add the remaining points to be removed later
-				if (m_anim_Control.GetPlaySpeed() < 0)
-				{
-					SEventEditorContainer* eventContainer = m_anim_Control.GetEventContainer();
-					int j = 0;
-					if (eventContainer != nullptr)
-					{
-						for (auto currEvent : eventContainer->events)
-						{
-							CreateActor(drawTarget, j, (TSharedPtr<STelemetryEvent>)currEvent, m_anim_Control.GetColor(), m_anim_Control.GetShapeType());
-							j++;
-						}
-					}
-				}
+                //If we are playing in reverse, we need to add the remaining points to be removed later
+                if (m_anim_Control.GetPlaySpeed() < 0)
+                {
+                    SEventEditorContainer* eventContainer = m_anim_Control.GetEventContainer();
+                    int j = 0;
+                    if (eventContainer != nullptr)
+                    {
+                        for (auto currEvent : eventContainer->events)
+                        {
+                            CreateActor(drawTarget, j, (TSharedPtr<STelemetryEvent>)currEvent, m_anim_Control.GetColor(), m_anim_Control.GetShapeType());
+                            j++;
+                        }
+                    }
+                }
 
-				FlushPersistentDebugLines(drawTarget);
-			}
+                FlushPersistentDebugLines(drawTarget);
+            }
 
-			TArray<TSharedPtr<STelemetryEvent>> tempArray;
+            TArray<TSharedPtr<STelemetryEvent>> tempArray;
 
-			if (m_anim_Control.GetPlaySpeed() >= 0)
-			{
-				if (m_heatmapAnimation)
-				{
-					//Regenerate the heatmap only using a subset of the events
-					int start = m_anim_Control.GetNextIndex();
-					int next = m_anim_Control.GetNextEventCount();
-					SEventEditorContainer* tempContainer = m_anim_Control.GetEventContainer();
-					m_anim_scrollBarLocation = m_anim_Control.GetTimeScaleFromTime();
-					if (start != next)
-					{
-						GenerateHeatmap(tempContainer, next, tempContainer->events.Num() - 1);
-					}
-				}
-				else
-				{
-					//Update forward point animation by getting events that have occured over the last timespan and creating them
-					tempArray = m_anim_Control.GetNextEvents();
-					int i = m_anim_Control.GetNextIndex();
-					m_anim_scrollBarLocation = m_anim_Control.GetTimeScaleFromTime();
-					for (auto currEvent : tempArray)
-					{
-						CreateActor(drawTarget, i, (TSharedPtr<STelemetryEvent>)currEvent, m_anim_Control.GetColor(), m_anim_Control.GetShapeType());
-						i++;
-					}
-				}
-			}
-			else
-			{
-				if (m_heatmapAnimation)
-				{
-					//Regenerate the heatmap only using a subset of the events
-					int start = m_anim_Control.GetPrevIndex();
-					int next = m_anim_Control.GetPrevEventCount();
-					SEventEditorContainer* tempContainer = m_anim_Control.GetEventContainer();
-					m_anim_scrollBarLocation = 1 + m_anim_Control.GetTimeScaleFromTime();
-					if (start != next)
-					{
-						GenerateHeatmap(tempContainer, next, tempContainer->events.Num() - 1);
-					}
-				}
-				else
-				{
-					//Update reverse point animation by removing the last actor for as many events occured over the last timespan
-					tempArray = m_anim_Control.GetPrevEvents();
-					m_anim_scrollBarLocation = 1 + m_anim_Control.GetTimeScaleFromTime();
-					for (auto currEvent : tempArray)
-					{
-						DestroyLastActor();
-					}
-				}
-			}
+            if (m_anim_Control.GetPlaySpeed() >= 0)
+            {
+                if (m_heatmapAnimation)
+                {
+                    //Regenerate the heatmap only using a subset of the events
+                    int start = m_anim_Control.GetNextIndex();
+                    int next = m_anim_Control.GetNextEventCount();
+                    SEventEditorContainer* tempContainer = m_anim_Control.GetEventContainer();
+                    m_anim_scrollBarLocation = m_anim_Control.GetTimeScaleFromTime();
+                    if (start != next)
+                    {
+                        GenerateHeatmap(tempContainer, next, tempContainer->events.Num() - 1);
+                    }
+                }
+                else
+                {
+                    //Update forward point animation by getting events that have occured over the last timespan and creating them
+                    tempArray = m_anim_Control.GetNextEvents();
+                    int i = m_anim_Control.GetNextIndex();
+                    m_anim_scrollBarLocation = m_anim_Control.GetTimeScaleFromTime();
+                    for (auto currEvent : tempArray)
+                    {
+                        CreateActor(drawTarget, i, (TSharedPtr<STelemetryEvent>)currEvent, m_anim_Control.GetColor(), m_anim_Control.GetShapeType());
+                        i++;
+                    }
+                }
+            }
+            else
+            {
+                if (m_heatmapAnimation)
+                {
+                    //Regenerate the heatmap only using a subset of the events
+                    int start = m_anim_Control.GetPrevIndex();
+                    int next = m_anim_Control.GetPrevEventCount();
+                    SEventEditorContainer* tempContainer = m_anim_Control.GetEventContainer();
+                    m_anim_scrollBarLocation = 1 + m_anim_Control.GetTimeScaleFromTime();
+                    if (start != next)
+                    {
+                        GenerateHeatmap(tempContainer, next, tempContainer->events.Num() - 1);
+                    }
+                }
+                else
+                {
+                    //Update reverse point animation by removing the last actor for as many events occured over the last timespan
+                    tempArray = m_anim_Control.GetPrevEvents();
+                    m_anim_scrollBarLocation = 1 + m_anim_Control.GetTimeScaleFromTime();
+                    for (auto currEvent : tempArray)
+                    {
+                        DestroyLastActor();
+                    }
+                }
+            }
 
-			//Set the location of the slider
-			if (!m_anim_Control.ShouldAnimate() && m_anim_Control.GetPlaySpeed() >= 0)
-			{
-				m_animationSlider->SetValue(1.f);
-			}
-			else if (!m_anim_Control.ShouldAnimate() && m_anim_Control.GetPlaySpeed() < 0)
-			{
-				m_animationSlider->SetValue(0.f);
-			}
-			else
-			{
-				m_animationSlider->SetValue(m_anim_scrollBarLocation);
-			}
+            //Set the location of the slider
+            if (!m_anim_Control.ShouldAnimate() && m_anim_Control.GetPlaySpeed() >= 0)
+            {
+                m_animationSlider->SetValue(1.f);
+            }
+            else if (!m_anim_Control.ShouldAnimate() && m_anim_Control.GetPlaySpeed() < 0)
+            {
+                m_animationSlider->SetValue(0.f);
+            }
+            else
+            {
+                m_animationSlider->SetValue(m_anim_scrollBarLocation);
+            }
 
-			//Update the current playtime
-			if (m_animationCurrentTime.IsValid())
-			{
-				FNumberFormattingOptions format;
-				format.MinimumIntegralDigits = 2;
+            //Update the current playtime
+            if (m_animationCurrentTime.IsValid())
+            {
+                FNumberFormattingOptions format;
+                format.MinimumIntegralDigits = 2;
 
-				FTimespan totalTime = m_anim_Control.GetCurrentPlayTime();
-				m_animationCurrentTime->SetText(FText::Format(FTextFormat::FromString("{0}:{1}"), FText::AsNumber(totalTime.GetMinutes()), FText::AsNumber(totalTime.GetSeconds(), &format)));
-			}
-		}
-	}
-	else
-	{
-		if (m_needsActorUpdate)
-		{
-			//Draw data points
-			m_needsActorUpdate = false;
-			DestroyActors();
-			FlushPersistentDebugLines(drawTarget);
+                FTimespan totalTime = m_anim_Control.GetCurrentPlayTime();
+                m_animationCurrentTime->SetText(FText::Format(FTextFormat::FromString("{0}:{1}"), FText::AsNumber(totalTime.GetMinutes()), FText::AsNumber(totalTime.GetSeconds(), &format)));
+            }
+        }
+    }
+    else
+    {
+        if (m_needsActorUpdate)
+        {
+            //Draw data points
+            m_needsActorUpdate = false;
+            DestroyActors();
+            FlushPersistentDebugLines(drawTarget);
 
-			for (auto events : m_filterCollection)
-			{
-				if (events->ShouldDraw())
-				{
-					int startIndex = 0;
-					int endIndex = events->events.Num();
+            for (auto events : m_filterCollection)
+            {
+                if (events->ShouldDraw())
+                {
+                    int startIndex = 0;
+                    int endIndex = events->events.Num();
 
-					CreateActors(drawTarget, events->events, startIndex, endIndex, events->GetColor(), events->GetShapeType());
-				}
-			}
-		}
-	}
+                    CreateActors(drawTarget, events->events, startIndex, endIndex, events->GetColor(), events->GetShapeType());
+                }
+            }
+        }
+    }
 
-	GEditor->RedrawAllViewports();
+    GEditor->RedrawAllViewports();
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.cpp
@@ -34,6 +34,8 @@ void FTelemetryVisualizerUI::Initialize()
 	m_anim_scrollBarLocation = 0.f;
 	m_eventgroupList.Add(MakeShareable<FString>(new FString("")));
 	m_vizSelection = m_eventgroupList[0];
+	m_eventgroupSubList.Add(MakeShareable<FString>(new FString("")));
+	m_subVizSelection = m_eventgroupSubList[0];
 
 	//Default heatmap state
 	m_heatmapType = HeatmapType::Population;

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
@@ -26,7 +26,6 @@
 #include "TelemetryEvent.h"
 #include "Query/TelemetryQuery.h"
 #include "Slate.h"
-#include "TelemetryVisualizerTypes.h"
 #include "Query/TelemetryQuery.h"
 
 static const float MinHeatmapSize = 50.f;
@@ -35,190 +34,190 @@ static const float MaxHeatmapSize = 1000.f;
 class FTelemetryVisualizerUI
 {
 public:
-	FTelemetryVisualizerUI() {}
-	virtual ~FTelemetryVisualizerUI() {};
+    FTelemetryVisualizerUI() {}
+    virtual ~FTelemetryVisualizerUI() {};
 
-	//Plugin state
-	void Initialize();
-	void Shutdown();
+    //Plugin state
+    void Initialize();
+    void Shutdown();
 
-	//Plugin state
-	UWorld* GetLocalWorld();
-	bool UpdateDraw(float val);
-	void UpdateGameState(bool allowPIE);
-	void PIEStarted(bool val) { UpdateGameState(true); };
-	void PIEEnded(bool val) { UpdateGameState(false); };
+    //Plugin state
+    UWorld* GetLocalWorld();
+    bool UpdateDraw(float val);
+    void UpdateGameState(bool allowPIE);
+    void PIEStarted(bool val) { UpdateGameState(true); };
+    void PIEEnded(bool val) { UpdateGameState(false); };
 
-	//Tab control
-	TSharedRef<SDockTab> SpawnDataTab(const FSpawnTabArgs& TabSpawnArgs);
-	TSharedRef<SDockTab> SpawnVizTab(const FSpawnTabArgs& TabSpawnArgs);
-	void ShowDataTab() { FGlobalTabmanager::Get()->InvokeTab(TelemetryDataIndirectTabName); }
-	void ShowVizTab() { FGlobalTabmanager::Get()->InvokeTab(TelemetryVizIndirectTabName); }
-	void ShowAll()
-	{
-		ShowDataTab();
-		ShowVizTab();
-	}
+    //Tab control
+    TSharedRef<SDockTab> SpawnDataTab(const FSpawnTabArgs& TabSpawnArgs);
+    TSharedRef<SDockTab> SpawnVizTab(const FSpawnTabArgs& TabSpawnArgs);
+    void ShowDataTab() { FGlobalTabmanager::Get()->InvokeTab(TelemetryDataIndirectTabName); }
+    void ShowVizTab() { FGlobalTabmanager::Get()->InvokeTab(TelemetryVizIndirectTabName); }
+    void ShowAll()
+    {
+        ShowDataTab();
+        ShowVizTab();
+    }
 
-	TSharedRef<SWidget> MakeWidgetForOption(TSharedPtr<FString> InOption);
-	void GenerateEventBox();
-	void GenerateSubEventBox(int index);
+    TSharedRef<SWidget> MakeWidgetForOption(TSharedPtr<FString> InOption);
+    void GenerateEventBox();
+    void GenerateSubEventBox(int index);
 
-	//Event Collection
-	void QueryResults(TSharedPtr<SQueryResult> results);
-	FReply UpdateFilterEvents();
-	int FilterEvents();
-	void CollectEvents(FQueryNodePtr query);
-	void GenerateScrollBoxes(int count);
+    //Event Collection
+    void QueryResults(TSharedPtr<SQueryResult> results);
+    FReply UpdateFilterEvents();
+    int FilterEvents();
+    void CollectEvents(FQueryNodePtr query);
+    void GenerateScrollBoxes(int count);
 
-	//Viz tab event selection
-	void OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
-	void OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
-	FText GetCurrentVizItem() const;
-	FText GetCurrentSubVizItem() const;
+    //Viz tab event selection
+    void OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+    void OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+    FText GetCurrentVizItem() const;
+    FText GetCurrentSubVizItem() const;
 
-	//Query Scroll box
-	void GenerateQueryScrollBox();
-	FText GetAndOrItem(int index) const;
-	void OnAndOrSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
-	FText GetFieldItem(int index) const;
-	void OnFieldSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
-	FText GetOperatorItem(int index) const;
-	void OnOperatorSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
-	void UpdateClauseValue(const FText& text, int index);
-	FReply AddClause(int index);
-	FReply RemoveClause(int index);
-	FReply SubmitQuery();
-	FText GetButtonString() const;
+    //Query Scroll box
+    void GenerateQueryScrollBox();
+    FText GetAndOrItem(int index) const;
+    void OnAndOrSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
+    FText GetFieldItem(int index) const;
+    void OnFieldSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
+    FText GetOperatorItem(int index) const;
+    void OnOperatorSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
+    void UpdateClauseValue(const FText& text, int index);
+    FReply AddClause(int index);
+    FReply RemoveClause(int index);
+    FReply SubmitQuery();
+    FText GetButtonString() const;
 
-	//Event filter Scroll box
-	void GenerateScrollBox();
-	FText GetTypeItem(int index) const;
-	void OnTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
-	void OnEventChecked(ECheckBoxState NewState, FText eventName);
-	FReply DisplayDrawColor(FText eventName, bool isHeatmap);
-	void SelectDrawColor(FLinearColor NewColor);
-	FReply SelectAll();
-	FReply SelectNone();
+    //Event filter Scroll box
+    void GenerateScrollBox();
+    FText GetTypeItem(int index) const;
+    void OnTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type, int index);
+    void OnEventChecked(ECheckBoxState NewState, FText eventName);
+    FReply DisplayDrawColor(FText eventName, bool isHeatmap);
+    void SelectDrawColor(FLinearColor NewColor);
+    FReply SelectAll();
+    FReply SelectNone();
 
 
-	//Animation
-	FReply PlayAnimation(int speed);
-	void AnimationTimelineScrolled(float NewLevel);
+    //Animation
+    FReply PlayAnimation(int speed);
+    void AnimationTimelineScrolled(float NewLevel);
 
-	//Heatmap
-	void OnHeatmapTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
-	void OnHeatmapShapeTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
-	void HeatmapSizeTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
-	void HeatmapMinValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
-	void HeatmapMaxValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
-	FText GetHeatmapTypeItem() const;
-	FText GetHeatmapShapeTypeItem() const;
-	FReply GenerateHeatmap();
-	FReply GenerateHeatmap(SEventEditorContainer* collection, int first, int last);
-	void SelectHeatmapDrawColor(FLinearColor NewColor);
-	void HeatmapSizeScrolled(float NewLevel);
-	void ResetRange();
-	void OnHeatmapOrientationChecked(ECheckBoxState NewState);
-	void OnHeatmapAnimationChecked(ECheckBoxState NewState);
-	//void CreateHeatmapActor(UWorld* drawTarget, int index, FVector location, int value, int range, EventType shape, float size);
-	//void CombineHeatmap();
+    //Heatmap
+    void OnHeatmapTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+    void OnHeatmapShapeTypeSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+    void HeatmapSizeTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
+    void HeatmapMinValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
+    void HeatmapMaxValueTextUpdate(const FText& InText, ETextCommit::Type InCommitType);
+    FText GetHeatmapTypeItem() const;
+    FText GetHeatmapShapeTypeItem() const;
+    FReply GenerateHeatmap();
+    FReply GenerateHeatmap(SEventEditorContainer* collection, int first, int last);
+    void SelectHeatmapDrawColor(FLinearColor NewColor);
+    void HeatmapSizeScrolled(float NewLevel);
+    void ResetRange();
+    void OnHeatmapOrientationChecked(ECheckBoxState NewState);
+    void OnHeatmapAnimationChecked(ECheckBoxState NewState);
+    //void CreateHeatmapActor(UWorld* drawTarget, int index, FVector location, int value, int range, EventType shape, float size);
+    //void CombineHeatmap();
 
-	//Draw calls
-	void DrawTelemetry(UWorld* drawTarget, TArray<SEventEditorContainer*> data);
-	void DrawPoint(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
-	void DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
-	void DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
-	void DrawSphere(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
-	void DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
-	void DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
-	void DrawCube(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
-	void DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
-	void DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
-	void CreateActor(UWorld* drawTarget, int index, TSharedPtr<STelemetryEvent> data, FColor color, EventType shape);
-	void CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color, EventType shape);
-	void CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color, EventType shape);
-	void DestroyActors();
-	void DestroyLastActor();
+    //Draw calls
+    void DrawTelemetry(UWorld* drawTarget, TArray<SEventEditorContainer*> data);
+    void DrawPoint(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
+    void DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
+    void DrawPoints(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
+    void DrawSphere(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
+    void DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
+    void DrawSpheres(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
+    void DrawCube(UWorld* drawTarget, TSharedPtr<STelemetryEvent> data, FColor color);
+    void DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color);
+    void DrawCubes(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color);
+    void CreateActor(UWorld* drawTarget, int index, TSharedPtr<STelemetryEvent> data, FColor color, EventType shape);
+    void CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, FColor color, EventType shape);
+    void CreateActors(UWorld* drawTarget, TArray<TSharedPtr<STelemetryEvent>> data, int start, int end, FColor color, EventType shape);
+    void DestroyActors();
+    void DestroyLastActor();
 
-	//Draw state
-	bool m_registeredWidget;
-	bool m_drawChecked;
-	bool m_needsActorUpdate;
-	FText m_eventColor;
+    //Draw state
+    bool m_registeredWidget;
+    bool m_drawChecked;
+    bool m_needsActorUpdate;
+    FText m_eventColor;
 
-	//Query tools
-	FQuerySerializer m_querySerializer;
-	FQueryExecutor m_queryExecuter;
-	QueryResultHandler m_queryResultHandler;
-	bool m_isWaiting;
+    //Query tools
+    FQuerySerializer m_querySerializer;
+    FQueryExecutor m_queryExecuter;
+    QueryResultHandler m_queryResultHandler;
+    bool m_isWaiting;
 
-	//Animation state
-	float m_anim_scrollBarLocation;
-	AnimationController m_anim_Control;
+    //Animation state
+    float m_anim_scrollBarLocation;
+    AnimationController m_anim_Control;
 
-	//Heatmap state
-	EventType m_heatmapShapeType;
-	HeatmapType m_heatmapType;
-	HeatmapColors m_heatmapColor;
-	UMaterial* m_material;
-	float m_heatmapSize;
-	int m_heatmapMinValue;
-	int m_heatmapMaxValue;
-	bool m_heatmapOrientation;
-	bool m_heatmapAnimation;
+    //Heatmap state
+    EventType m_heatmapShapeType;
+    HeatmapType m_heatmapType;
+    HeatmapColors m_heatmapColor;
+    UMaterial* m_material;
+    float m_heatmapSize;
+    double m_heatmapMinValue;
+    double m_heatmapMaxValue;
+    bool m_heatmapOrientation;
+    bool m_heatmapAnimation;
 
-	//Draw targets
-	UWorld* m_editorDrawTarget;
-	UWorld* m_PIEDrawTarget;
-	UWorld* m_gameDrawTarget;
+    //Draw targets
+    UWorld* m_editorDrawTarget;
+    UWorld* m_PIEDrawTarget;
+    UWorld* m_gameDrawTarget;
 
-	//Window elements
-	TSharedPtr<SEditableTextBox> m_searchText;
-	TArray<TSharedPtr<SEditableTextBox>> m_valueText;
-	TSharedPtr<SEditableTextBox> m_heatmapSizeText;
-	TSharedPtr<SEditableTextBox> m_heatmapMinValueText;
-	TSharedPtr<SEditableTextBox> m_heatmapMaxValueText;
-	TSharedPtr<STextBlock> m_messageText;
-	TSharedPtr<STextBlock> m_animationCurrentTime;
-	TSharedPtr<STextBlock> m_animationTotalTime;
-	TSharedPtr<SScrollBox> m_scrollBox;
-	TSharedPtr<SScrollBox> m_queryScrollBox;
-	TArray<TSharedPtr<FString>> m_eventgroupList;
-	TArray<TSharedPtr<FString>> m_eventgroupSubList;
-	TArray<TSharedPtr<FString>> m_shapeList;
-	TArray<TSharedPtr<FString>> m_heatmapTypeList;
-	TArray<TSharedPtr<FString>> m_queryFieldList;
-	TArray<TSharedPtr<FString>> m_queryOperatorList;
-	TArray<TSharedPtr<FString>> m_queryAndOrList;
-	TSharedPtr<FString> m_vizSelection;
-	TSharedPtr<FString> m_subVizSelection;
-	TSharedPtr<SSlider> m_animationSlider;
-	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizChoice;
-	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizSubChoice;
-	TSharedPtr<SBorder> m_heatmapLowColorButton;
-	TSharedPtr<SBorder> m_heatmapHighColorButton;
+    //Window elements
+    TSharedPtr<SEditableTextBox> m_searchText;
+    TArray<TSharedPtr<SEditableTextBox>> m_valueText;
+    TSharedPtr<SEditableTextBox> m_heatmapSizeText;
+    TSharedPtr<SEditableTextBox> m_heatmapMinValueText;
+    TSharedPtr<SEditableTextBox> m_heatmapMaxValueText;
+    TSharedPtr<STextBlock> m_messageText;
+    TSharedPtr<STextBlock> m_animationCurrentTime;
+    TSharedPtr<STextBlock> m_animationTotalTime;
+    TSharedPtr<SScrollBox> m_scrollBox;
+    TSharedPtr<SScrollBox> m_queryScrollBox;
+    TArray<TSharedPtr<FString>> m_eventgroupList;
+    TArray<TSharedPtr<FString>> m_eventgroupSubList;
+    TArray<TSharedPtr<FString>> m_shapeList;
+    TArray<TSharedPtr<FString>> m_heatmapTypeList;
+    TArray<TSharedPtr<FString>> m_queryFieldList;
+    TArray<TSharedPtr<FString>> m_queryOperatorList;
+    TArray<TSharedPtr<FString>> m_queryAndOrList;
+    TSharedPtr<FString> m_vizSelection;
+    TSharedPtr<FString> m_subVizSelection;
+    TSharedPtr<SSlider> m_animationSlider;
+    TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizChoice;
+    TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizSubChoice;
+    TSharedPtr<SBorder> m_heatmapLowColorButton;
+    TSharedPtr<SBorder> m_heatmapHighColorButton;
 
-	//Update timer
-	FDelegateHandle m_tickDelegateHandle;
-	FDelegateHandle m_startPIEDelegateHandle;
-	FDelegateHandle m_endPIEDelegateHandle;
+    //Update timer
+    FDelegateHandle m_tickDelegateHandle;
+    FDelegateHandle m_startPIEDelegateHandle;
+    FDelegateHandle m_endPIEDelegateHandle;
 
-	//Editor flags/data
-	void AddMenuExtensions(FMenuBuilder &);
-	TSharedPtr<FUICommandList> m_pluginCommands;
-	TSharedPtr<FExtensibilityManager> m_extensionManager;
-	TSharedPtr< const FExtensionBase > m_menuExtension;
-	TSharedPtr<FExtender> m_menuExtender;
+    //Editor flags/data
+    void AddMenuExtensions(FMenuBuilder &);
+    TSharedPtr<FUICommandList> m_pluginCommands;
+    TSharedPtr<FExtensibilityManager> m_extensionManager;
+    TSharedPtr< const FExtensionBase > m_menuExtension;
+    TSharedPtr<FExtender> m_menuExtender;
 
-	//All queried events
-	TArray<SEventEditorContainer> m_queryEventCollection;
-	TArray<SEventEditorContainer*> m_filterCollection;
+    //All queried events
+    TArray<SEventEditorContainer> m_queryEventCollection;
+    TArray<SEventEditorContainer*> m_filterCollection;
 
-	//Query settings
-	TArray<SQuerySetting> m_queryCollection;
+    //Query settings
+    TArray<SQuerySetting> m_queryCollection;
 
-	//All drawn actors
-	TArray<AActor*> m_eventActors;
+    //All drawn actors
+    TArray<AActor*> m_eventActors;
 };
 

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Private/TelemetryVisualizerUI.h
@@ -62,6 +62,7 @@ public:
 
 	TSharedRef<SWidget> MakeWidgetForOption(TSharedPtr<FString> InOption);
 	void GenerateEventBox();
+	void GenerateSubEventBox(int index);
 
 	//Event Collection
 	void QueryResults(TSharedPtr<SQueryResult> results);
@@ -72,7 +73,9 @@ public:
 
 	//Viz tab event selection
 	void OnVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
+	void OnSubVizSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type);
 	FText GetCurrentVizItem() const;
+	FText GetCurrentSubVizItem() const;
 
 	//Query Scroll box
 	void GenerateQueryScrollBox();
@@ -182,14 +185,17 @@ public:
 	TSharedPtr<SScrollBox> m_scrollBox;
 	TSharedPtr<SScrollBox> m_queryScrollBox;
 	TArray<TSharedPtr<FString>> m_eventgroupList;
+	TArray<TSharedPtr<FString>> m_eventgroupSubList;
 	TArray<TSharedPtr<FString>> m_shapeList;
 	TArray<TSharedPtr<FString>> m_heatmapTypeList;
 	TArray<TSharedPtr<FString>> m_queryFieldList;
 	TArray<TSharedPtr<FString>> m_queryOperatorList;
 	TArray<TSharedPtr<FString>> m_queryAndOrList;
 	TSharedPtr<FString> m_vizSelection;
+	TSharedPtr<FString> m_subVizSelection;
 	TSharedPtr<SSlider> m_animationSlider;
 	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizChoice;
+	TSharedPtr<SComboBox<TSharedPtr<FString>>> m_vizSubChoice;
 	TSharedPtr<SBorder> m_heatmapLowColorButton;
 	TSharedPtr<SBorder> m_heatmapHighColorButton;
 

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
@@ -358,6 +358,17 @@ public:
 		return GetVector(CAM_DIR);
 	}
 
+	void GetAttributes(TMap<FString, TSharedPtr<FJsonValue>>& inMap)
+	{
+		for (auto& attr : Attributes)
+		{
+			if (attr.Key.StartsWith("pct_") || attr.Key.StartsWith("val_"))
+			{
+				inMap.Add(attr.Key, attr.Value);
+			}
+		}
+	}
+
 	bool GetString(const FString &Name, FString &OutString) const
 	{
 		TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/Query/TelemetryQuery.h
@@ -8,7 +8,10 @@
 //--------------------------------------------------------------------------------------
 
 #include "CoreMinimal.h"
-#include "Json.h"
+#include "Misc/Variant.h"
+#include "Dom/JsonValue.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Serialization/JsonSerializer.h"
 #include "Http.h"
 #include "TelemetryService.h"
 
@@ -29,23 +32,23 @@ using FQueryNodeList = TArray<TSharedPtr<FQueryNode>>;
 //Query identifier (single comparison or container of nodes)
 enum class EQueryNodeType
 {
-	Comparison = 0,
-	Group = 1
+    Comparison = 0,
+    Group = 1
 };
 
 //Query operator
 enum class EQueryOp
 {
-	Eq = 0,
-	Gt = 1,
-	Gte = 2,
-	Lt = 3,
-	Lte = 4,
-	Neq = 5,
-	In = 6,
-	Btwn = 7,
-	And = 8,
-	Or = 9,
+    Eq = 0,
+    Gt = 1,
+    Gte = 2,
+    Lt = 3,
+    Lte = 4,
+    Neq = 5,
+    In = 6,
+    Btwn = 7,
+    And = 8,
+    Or = 9,
 };
 
 //JSON value converter
@@ -53,187 +56,187 @@ class FJsonValueUtil
 {
 public:
 
-	static inline TSharedPtr<FJsonValue> Create(FString Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueString(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(FString Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueString(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(FGuid Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueString(Value.ToString()));
-	}
+    static inline TSharedPtr<FJsonValue> Create(FGuid Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueString(Value.ToString()));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(double Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(double Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(float Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(float Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(int64 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(int64 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(int32 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(int32 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(int16 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(int16 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(int8 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(int8 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(uint64 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(uint64 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(uint32 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(uint32 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(uint16 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(uint16 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(uint8 Value)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
-	}
+    static inline TSharedPtr<FJsonValue> Create(uint8 Value)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueNumber(Value));
+    }
 
-	static inline TSharedPtr<FJsonValue> Create(const TArray<TSharedPtr<FJsonValue>> &Array)
-	{
-		return TSharedPtr<FJsonValue>(new FJsonValueArray(Array));
-	}
+    static inline TSharedPtr<FJsonValue> Create(const TArray<TSharedPtr<FJsonValue>> &Array)
+    {
+        return TSharedPtr<FJsonValue>(new FJsonValueArray(Array));
+    }
 };
 
 //Nodes for query conditions and containers
 struct FQueryNode
 {
-	EQueryNodeType Type;
+    EQueryNodeType Type;
 
-	EQueryOp Operator;
+    EQueryOp Operator;
 
-	FString Column;
+    FString Column;
 
-	TSharedPtr<FQueryNodeList> Children;
+    TSharedPtr<FQueryNodeList> Children;
 
-	TSharedPtr<FJsonValue> Value;
-	
-	// Standard single value node
-	FQueryNode(EQueryNodeType Type, FString Column, EQueryOp Op, TSharedPtr<FJsonValue> &&Value) :
-		Type(Type),
-		Column(Column),
-		Operator(Op),
-		Value(MoveTemp(Value))
-	{
-	}
+    TSharedPtr<FJsonValue> Value;
+    
+    // Standard single value node
+    FQueryNode(EQueryNodeType Type, FString Column, EQueryOp Op, TSharedPtr<FJsonValue> &&Value) :
+        Type(Type),
+        Column(Column),
+        Operator(Op),
+        Value(MoveTemp(Value))
+    {
+    }
 
-	// Overload for BETWEEN query nodes
-	FQueryNode(EQueryNodeType Type, FString Column, EQueryOp Op, TSharedPtr<FJsonValue> &&Value1, TSharedPtr<FJsonValue> &&Value2) :
-		Type(Type),
-		Column(Column),
-		Operator(Op),
-		Value(FJsonValueUtil::Create(TArray<TSharedPtr<FJsonValue>>({ MoveTemp(Value1), MoveTemp(Value2) })))
-	{
-		// Between and In operators are the only ones that know to look at the Values array
-		check(Op == EQueryOp::Btwn || Op == EQueryOp::In);
-	}
+    // Overload for BETWEEN query nodes
+    FQueryNode(EQueryNodeType Type, FString Column, EQueryOp Op, TSharedPtr<FJsonValue> &&Value1, TSharedPtr<FJsonValue> &&Value2) :
+        Type(Type),
+        Column(Column),
+        Operator(Op),
+        Value(FJsonValueUtil::Create(TArray<TSharedPtr<FJsonValue>>({ MoveTemp(Value1), MoveTemp(Value2) })))
+    {
+        // Between and In operators are the only ones that know to look at the Values array
+        check(Op == EQueryOp::Btwn || Op == EQueryOp::In);
+    }
 
-	// Overload for grouping nodes (AND, OR)
-	FQueryNode(EQueryNodeType Type, EQueryOp Op, FQueryNodeList &&ChildNodes) :
-		Type(Type),
-		Operator(Op),
-		Children(new FQueryNodeList(MoveTemp(ChildNodes)))
-	{
-	}
+    // Overload for grouping nodes (AND, OR)
+    FQueryNode(EQueryNodeType Type, EQueryOp Op, FQueryNodeList &&ChildNodes) :
+        Type(Type),
+        Operator(Op),
+        Children(new FQueryNodeList(MoveTemp(ChildNodes)))
+    {
+    }
 
 private:
-	bool ValidateBetweenRange(FJsonValue &Value1, FJsonValue &Value2)
-	{
-		if (Value1.Type != Value2.Type) { return false; }
+    bool ValidateBetweenRange(FJsonValue &Value1, FJsonValue &Value2)
+    {
+        if (Value1.Type != Value2.Type) { return false; }
 
-		if (Value1.Type == EJson::Number)
-		{
-			return (Value1.AsNumber() <= Value2.AsNumber());
-		}
-		else if (Value1.Type == EJson::String)
-		{
-			return (Value1.AsString() <= Value2.AsString());
-		}
-		else
-		{
-			return false;
-		}
-	}
+        if (Value1.Type == EJson::Number)
+        {
+            return (Value1.AsNumber() <= Value2.AsNumber());
+        }
+        else if (Value1.Type == EJson::String)
+        {
+            return (Value1.AsString() <= Value2.AsString());
+        }
+        else
+        {
+            return false;
+        }
+    }
 };
 
 //Helper for building query nodes
 class QBuilder
 {
 private:
-	// Nodes for comparing a column to a single value (e.g. equals, greater than, etc.)
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> CreateComparisonNode(FString Column, EQueryOp Op, T Value)
-	{
-		return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Comparison, Column, Op, FJsonValueUtil::Create(Value)));
-	}
+    // Nodes for comparing a column to a single value (e.g. equals, greater than, etc.)
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> CreateComparisonNode(FString Column, EQueryOp Op, T Value)
+    {
+        return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Comparison, Column, Op, FJsonValueUtil::Create(Value)));
+    }
 
-	// Nodes for comparing a column to multiple values (e.g. between)
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> CreateComparisonNode(FString Column, EQueryOp Op, T Value1, T Value2)
-	{
-		return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Comparison, Column, Op, FJsonValueUtil::Create(Value1), FJsonValueUtil::Create(Value2)));
-	}
+    // Nodes for comparing a column to multiple values (e.g. between)
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> CreateComparisonNode(FString Column, EQueryOp Op, T Value1, T Value2)
+    {
+        return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Comparison, Column, Op, FJsonValueUtil::Create(Value1), FJsonValueUtil::Create(Value2)));
+    }
 
-	// Nodes for grouping multiple nodes together with a common query operator (e.g. and, or)
-	static inline TSharedPtr<FQueryNode> CreateGroupNode(EQueryOp Op, FQueryNodeList &&ChildNodes)
-	{
-		return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Group, Op, MoveTemp(ChildNodes)));
-	}
+    // Nodes for grouping multiple nodes together with a common query operator (e.g. and, or)
+    static inline TSharedPtr<FQueryNode> CreateGroupNode(EQueryOp Op, FQueryNodeList &&ChildNodes)
+    {
+        return TSharedPtr<FQueryNode>(new FQueryNode(EQueryNodeType::Group, Op, MoveTemp(ChildNodes)));
+    }
 
 
 public:
 
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Eq(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Eq, Value); }
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Eq(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Eq, Value); }
 
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Gt(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Gt, Value); }
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Gt(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Gt, Value); }
 
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Gte(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Gte, Value); }
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Gte(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Gte, Value); }
 
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Lt(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Lt, Value); }
-	
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Lte(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Lte, Value); }
-	
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Neq(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Neq, Value); }
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Lt(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Lt, Value); }
+    
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Lte(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Lte, Value); }
+    
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Neq(FString Column, T Value) { return CreateComparisonNode(Column, EQueryOp::Neq, Value); }
 
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> In(FString Column, TArray<T> &&Values) { return CreateComparisonNode(Column, EQueryOp::In, MoveTemp(Values)); }
-	
-	template<typename T>
-	static inline TSharedPtr<FQueryNode> Btwn(FString Column, T LowerBound, T UpperBound) { return CreateComparisonNode(Column, EQueryOp::Btwn, LowerBound, UpperBound); }
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> In(FString Column, TArray<T> &&Values) { return CreateComparisonNode(Column, EQueryOp::In, MoveTemp(Values)); }
+    
+    template<typename T>
+    static inline TSharedPtr<FQueryNode> Btwn(FString Column, T LowerBound, T UpperBound) { return CreateComparisonNode(Column, EQueryOp::Btwn, LowerBound, UpperBound); }
 
-	static inline TSharedPtr<FQueryNode> And(FQueryNodeList &&ChildNodes) { return CreateGroupNode(EQueryOp::And, MoveTemp(ChildNodes)); }
-	
-	static inline TSharedPtr<FQueryNode> Or(FQueryNodeList &&ChildNodes) { return CreateGroupNode(EQueryOp::Or, MoveTemp(ChildNodes)); }
+    static inline TSharedPtr<FQueryNode> And(FQueryNodeList &&ChildNodes) { return CreateGroupNode(EQueryOp::And, MoveTemp(ChildNodes)); }
+    
+    static inline TSharedPtr<FQueryNode> Or(FQueryNodeList &&ChildNodes) { return CreateGroupNode(EQueryOp::Or, MoveTemp(ChildNodes)); }
 
 };
 
@@ -241,368 +244,368 @@ public:
 class FQuerySerializer
 {
 public:
-	FString Serialize(const FQueryNodePtr Node);
+    FString Serialize(const FQueryNodePtr Node);
 
 private:
 
-	void Serialize(const FQueryNodePtr &Node, TSharedRef<TJsonWriter<>> &Writer);
-	void Serialize(FQueryNodeList &Nodes, TSharedRef<TJsonWriter<>> &Writer);
+    void Serialize(const FQueryNodePtr &Node, TSharedRef<TJsonWriter<>> &Writer);
+    void Serialize(FQueryNodeList &Nodes, TSharedRef<TJsonWriter<>> &Writer);
 };
 
 //Interface for standard event data
 class ITelemetryEventData
 {
 public:
-	virtual FString GetId() const = 0;
-	virtual FString GetClientId() const = 0;
-	virtual FString GetSessionId() const = 0;
-	virtual FString GetName() const = 0;
-	virtual FString GetBuildType() const = 0;
-	virtual FString GetBuildId() const = 0;
-	virtual FString GetPlatform() const = 0;
-	virtual FString GetUserId() const = 0;
-	virtual FString GetCategory() const = 0;
+    virtual FString GetId() const = 0;
+    virtual FString GetClientId() const = 0;
+    virtual FString GetSessionId() const = 0;
+    virtual FString GetName() const = 0;
+    virtual FString GetBuildType() const = 0;
+    virtual FString GetBuildId() const = 0;
+    virtual FString GetPlatform() const = 0;
+    virtual FString GetUserId() const = 0;
+    virtual FString GetCategory() const = 0;
 
-	virtual uint32 GetSequence() const = 0;
-	virtual FDateTime GetTime() const = 0;
+    virtual uint32 GetSequence() const = 0;
+    virtual FDateTime GetTime() const = 0;
 
-	virtual FVector GetPlayerPosition() const = 0;
-	virtual FVector GetPlayerDirection() const = 0;
-	virtual FVector GetCameraPosition() const = 0;
-	virtual FVector GetCameraDirection() const = 0;
+    virtual FVector GetPlayerPosition() const = 0;
+    virtual FVector GetPlayerDirection() const = 0;
+    virtual FVector GetCameraPosition() const = 0;
+    virtual FVector GetCameraDirection() const = 0;
 
-	virtual FString GetString(const FString &Name) const = 0;
-	virtual double GetNumber(const FString &Name) const = 0;
-	virtual FVector GetVector(const FString &BaseName) const = 0;
-	virtual FDateTime GetDateTime(const FString &Name) const = 0;
-	virtual bool GetBool(const FString &Name) const = 0;
+    virtual FString GetString(const FString &Name) const = 0;
+    virtual double GetNumber(const FString &Name) const = 0;
+    virtual FVector GetVector(const FString &BaseName) const = 0;
+    virtual FDateTime GetDateTime(const FString &Name) const = 0;
+    virtual bool GetBool(const FString &Name) const = 0;
 };
 
 //Wrapper for each event
 class FSimpleEvent : public ITelemetryEventData
 {
-	const TCHAR *PLAYER_POS = TEXT("pos");
-	const TCHAR *PLAYER_DIR = TEXT("dir");
-	const TCHAR *CAM_POS = TEXT("cam_pos");
-	const TCHAR *CAM_DIR = TEXT("cam_dir");
-	const TCHAR *ID = TEXT("id");
-	const TCHAR *CLIENT_ID = TEXT("client_id");
-	const TCHAR *SESSION_ID = TEXT("session_id");
-	const TCHAR *SEQUENCE = TEXT("seq");
-	const TCHAR *EVENT_NAME = TEXT("name");
-	const TCHAR *EVENT_ACTION = TEXT("action");
-	const TCHAR *CLIENT_TIMESTAMP = TEXT("client_ts");
-	const TCHAR *EVENT_VERSION = TEXT("e_ver");
-	const TCHAR *BUILD_TYPE = TEXT("build_type");
-	const TCHAR *BUILD_ID = TEXT("build_id");
-	const TCHAR *PLATFORM = TEXT("platform");
-	const TCHAR *USER_ID = TEXT("user_id");
-	const TCHAR *CATEGORY = TEXT("cat");
+    const TCHAR *PLAYER_POS = TEXT("pos");
+    const TCHAR *PLAYER_DIR = TEXT("dir");
+    const TCHAR *CAM_POS = TEXT("cam_pos");
+    const TCHAR *CAM_DIR = TEXT("cam_dir");
+    const TCHAR *ID = TEXT("id");
+    const TCHAR *CLIENT_ID = TEXT("client_id");
+    const TCHAR *SESSION_ID = TEXT("session_id");
+    const TCHAR *SEQUENCE = TEXT("seq");
+    const TCHAR *EVENT_NAME = TEXT("name");
+    const TCHAR *EVENT_ACTION = TEXT("action");
+    const TCHAR *CLIENT_TIMESTAMP = TEXT("client_ts");
+    const TCHAR *EVENT_VERSION = TEXT("e_ver");
+    const TCHAR *BUILD_TYPE = TEXT("build_type");
+    const TCHAR *BUILD_ID = TEXT("build_id");
+    const TCHAR *PLATFORM = TEXT("platform");
+    const TCHAR *USER_ID = TEXT("user_id");
+    const TCHAR *CATEGORY = TEXT("cat");
 
-	TMap<FString, TSharedPtr<FJsonValue>> Attributes;
+    TMap<FString, TSharedPtr<FJsonValue>> Attributes;
 
 public:
-	virtual ~FSimpleEvent() {}
+    virtual ~FSimpleEvent() {}
 
-	FString GetId() const override { return GetString(ID); }
-	FString GetClientId() const override { return GetString(CLIENT_ID); }
-	FString GetSessionId() const override { return GetString(SESSION_ID); }
-	FString GetName() const override { return GetString(EVENT_NAME); }
-	FString GetBuildType() const override { return GetString(BUILD_TYPE); }
-	FString GetBuildId() const override { return GetString(BUILD_ID); }
-	FString GetPlatform() const override { return GetString(PLATFORM); }
-	FString GetUserId() const override { return GetString(USER_ID); }
-	FString GetCategory() const override { return GetString(CATEGORY); }
+    FString GetId() const override { return GetString(ID); }
+    FString GetClientId() const override { return GetString(CLIENT_ID); }
+    FString GetSessionId() const override { return GetString(SESSION_ID); }
+    FString GetName() const override { return GetString(EVENT_NAME); }
+    FString GetBuildType() const override { return GetString(BUILD_TYPE); }
+    FString GetBuildId() const override { return GetString(BUILD_ID); }
+    FString GetPlatform() const override { return GetString(PLATFORM); }
+    FString GetUserId() const override { return GetString(USER_ID); }
+    FString GetCategory() const override { return GetString(CATEGORY); }
 
-	uint32 GetSequence() const override { return (uint32)GetNumber(SEQUENCE); }
+    uint32 GetSequence() const override { return (uint32)GetNumber(SEQUENCE); }
 
-	FDateTime GetTime() const override
-	{
-		FDateTime Dt;
-		FDateTime::ParseIso8601(*GetString(CLIENT_TIMESTAMP), Dt);
-		return Dt;
-	}
+    FDateTime GetTime() const override
+    {
+        FDateTime Dt;
+        FDateTime::ParseIso8601(*GetString(CLIENT_TIMESTAMP), Dt);
+        return Dt;
+    }
 
-	FDateTime GetDateTime(const FString &Name) const override
-	{
-		FDateTime Dt;
-		FDateTime::ParseIso8601(*Name, Dt);
-		return Dt;
-	}
+    FDateTime GetDateTime(const FString &Name) const override
+    {
+        FDateTime Dt;
+        FDateTime::ParseIso8601(*Name, Dt);
+        return Dt;
+    }
 
-	static FSimpleEvent Parse(TSharedPtr<FJsonObject> JObj)
-	{
-		FSimpleEvent ev;
-		ev.Attributes.Append(JObj->Values);
+    static FSimpleEvent Parse(TSharedPtr<FJsonObject> JObj)
+    {
+        FSimpleEvent ev;
+        ev.Attributes.Append(JObj->Values);
 
-		return ev;
-	}
+        return ev;
+    }
 
-	FVector GetPlayerPosition() const override
-	{
-		return GetVector(PLAYER_POS);
-	}
+    FVector GetPlayerPosition() const override
+    {
+        return GetVector(PLAYER_POS);
+    }
 
-	FVector GetPlayerDirection() const override
-	{
-		return GetVector(PLAYER_DIR);
-	}
+    FVector GetPlayerDirection() const override
+    {
+        return GetVector(PLAYER_DIR);
+    }
 
-	FVector GetCameraPosition() const override
-	{
-		return GetVector(CAM_POS);
-	}
+    FVector GetCameraPosition() const override
+    {
+        return GetVector(CAM_POS);
+    }
 
-	FVector GetCameraDirection() const override
-	{
-		return GetVector(CAM_DIR);
-	}
+    FVector GetCameraDirection() const override
+    {
+        return GetVector(CAM_DIR);
+    }
 
-	void GetAttributes(TMap<FString, TSharedPtr<FJsonValue>>& inMap)
-	{
-		for (auto& attr : Attributes)
-		{
-			if (attr.Key.StartsWith("pct_") || attr.Key.StartsWith("val_"))
-			{
-				inMap.Add(attr.Key, attr.Value);
-			}
-		}
-	}
+    void GetAttributes(TMap<FString, TSharedPtr<FJsonValue>>& inMap)
+    {
+        for (auto& attr : Attributes)
+        {
+            if (attr.Key.StartsWith("pct_") || attr.Key.StartsWith("val_"))
+            {
+                inMap.Add(attr.Key, attr.Value);
+            }
+        }
+    }
 
-	bool GetString(const FString &Name, FString &OutString) const
-	{
-		TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
-		if (Value.IsValid())
-		{
-			OutString.Append(Value->AsString());
-			return true;
-		}
-		return false;
-	}
+    bool GetString(const FString &Name, FString &OutString) const
+    {
+        TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
+        if (Value.IsValid())
+        {
+            OutString.Append(Value->AsString());
+            return true;
+        }
+        return false;
+    }
 
-	FString GetString(const FString &Name) const override
-	{
-		FString Value;
-		GetString(Name, Value);
-		return Value;
-	}
+    FString GetString(const FString &Name) const override
+    {
+        FString Value;
+        GetString(Name, Value);
+        return Value;
+    }
 
-	bool GetNumber(const FString &Name, double &Number) const
-	{
-		TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
-		if (Value.IsValid())
-		{
-			Number = Value->AsNumber();
-			return true;
-		}
-		return false;
-	}
+    bool GetNumber(const FString &Name, double &Number) const
+    {
+        TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
+        if (Value.IsValid())
+        {
+            Number = Value->AsNumber();
+            return true;
+        }
+        return false;
+    }
 
-	double GetNumber(const FString &Name) const override
-	{
-		double Value;
-		GetNumber(Name, Value);
-		return Value;
-	}
+    double GetNumber(const FString &Name) const override
+    {
+        double Value;
+        GetNumber(Name, Value);
+        return Value;
+    }
 
-	bool GetVector(const FString &BaseName, FVector &Vector) const
-	{
-		float X, Y, Z;
-		TSharedPtr<FJsonValue> Value = Attributes.FindRef(BaseName + TEXT("_x"));
-		if (Value.IsValid())
-		{
-			X = Value->AsNumber();
-		}
-		else { return false; }
+    bool GetVector(const FString &BaseName, FVector &Vector) const
+    {
+        float X, Y, Z;
+        TSharedPtr<FJsonValue> Value = Attributes.FindRef(BaseName + TEXT("_x"));
+        if (Value.IsValid())
+        {
+            X = Value->AsNumber();
+        }
+        else { return false; }
 
-		Value = Attributes.FindRef(BaseName + TEXT("_y"));
-		if (Value.IsValid())
-		{
-			Y = Value->AsNumber();
-		}
-		else { return false; }
+        Value = Attributes.FindRef(BaseName + TEXT("_y"));
+        if (Value.IsValid())
+        {
+            Y = Value->AsNumber();
+        }
+        else { return false; }
 
-		Value = Attributes.FindRef(BaseName + TEXT("_z"));
-		if (Value.IsValid())
-		{
-			Z = Value->AsNumber();
+        Value = Attributes.FindRef(BaseName + TEXT("_z"));
+        if (Value.IsValid())
+        {
+            Z = Value->AsNumber();
 
-			Vector.X = X;
-			Vector.Y = Y;
-			Vector.Z = Z;
+            Vector.X = X;
+            Vector.Y = Y;
+            Vector.Z = Z;
 
-			return true;
-		}
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	FVector GetVector(const FString &BaseName) const override
-	{
-		FVector Vector;
-		GetVector(BaseName, Vector);
-		return Vector;
-	}
+    FVector GetVector(const FString &BaseName) const override
+    {
+        FVector Vector;
+        GetVector(BaseName, Vector);
+        return Vector;
+    }
 
-	bool GetBool(const FString &Name, bool &OutBool) const
-	{
-		TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
-		if (Value.IsValid())
-		{
-			double OutD;
-			if (!Value->TryGetBool(OutBool))
-			{
-				if (!Value->TryGetNumber(OutD))
-				{
-					return false;
-				}
-				OutBool = (OutD == 1.0);
-			}
-			return true;
-		}
-		return false;
-	}
+    bool GetBool(const FString &Name, bool &OutBool) const
+    {
+        TSharedPtr<FJsonValue> Value = Attributes.FindRef(Name);
+        if (Value.IsValid())
+        {
+            double OutD;
+            if (!Value->TryGetBool(OutBool))
+            {
+                if (!Value->TryGetNumber(OutD))
+                {
+                    return false;
+                }
+                OutBool = (OutD == 1.0);
+            }
+            return true;
+        }
+        return false;
+    }
 
-	bool GetBool(const FString &Name) const
-	{
-		bool Value = false;
-		GetBool(Name, Value);
-		return Value;
-	}
+    bool GetBool(const FString &Name) const
+    {
+        bool Value = false;
+        GetBool(Name, Value);
+        return Value;
+    }
 };
 
 //Result data structure for query request
 struct SQueryResult
 {
-	struct SQueryResultHeader
-	{
-		bool Success;
-		int Count;
-		long QueryTime;
-	} Header;
+    struct SQueryResultHeader
+    {
+        bool Success;
+        int Count;
+        long QueryTime;
+    } Header;
 
-	TArray<FSimpleEvent> Events;
+    TArray<FSimpleEvent> Events;
 
-	static TSharedPtr<SQueryResult> Parse(const FString &Response)
-	{
-		TSharedPtr<SQueryResult> Result(new SQueryResult);
-		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Response);
-		TSharedPtr<FJsonObject> RootObject;
-		if (FJsonSerializer::Deserialize(Reader, RootObject))
-		{
-			FJsonObject &Root = *RootObject;
-			TSharedPtr<FJsonObject> Header = Root.GetObjectField(TEXT("Header"));
-			TArray<TSharedPtr<FJsonValue>> Events = Root.GetArrayField(TEXT("Results"));
+    static TSharedPtr<SQueryResult> Parse(const FString &Response)
+    {
+        TSharedPtr<SQueryResult> Result(new SQueryResult);
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Response);
+        TSharedPtr<FJsonObject> RootObject;
+        if (FJsonSerializer::Deserialize(Reader, RootObject))
+        {
+            FJsonObject &Root = *RootObject;
+            TSharedPtr<FJsonObject> Header = Root.GetObjectField(TEXT("Header"));
+            TArray<TSharedPtr<FJsonValue>> Events = Root.GetArrayField(TEXT("Results"));
 
-			Result->Header.Success = Header->GetBoolField("Success");
-			Result->Header.Count = Header->GetNumberField("Count");
-			Result->Header.QueryTime = Header->GetNumberField("QueryTime");
+            Result->Header.Success = Header->GetBoolField("Success");
+            Result->Header.Count = Header->GetNumberField("Count");
+            Result->Header.QueryTime = Header->GetNumberField("QueryTime");
 
-			for (TSharedPtr<FJsonValue> Event : Events)
-			{
-				Result->Events.Add(FSimpleEvent::Parse(Event->AsObject()));
-			}
-		}
+            for (TSharedPtr<FJsonValue> Event : Events)
+            {
+                Result->Events.Add(FSimpleEvent::Parse(Event->AsObject()));
+            }
+        }
 
-		return Result;
-	}
+        return Result;
+    }
 };
 
 //Query execution
 class FQueryExecutor
 {
 public:
-	FQueryExecutor() : IsInitialized(false) {}
+    FQueryExecutor() : IsInitialized(false) {}
 
-	void ExecuteCustomQuery(const FString &QueryText, QueryResultHandler HandlerFunc)
-	{
-		ExecuteCustomQuery(QueryText, HandlerFunc, -1);
-	}
+    void ExecuteCustomQuery(const FString &QueryText, QueryResultHandler HandlerFunc)
+    {
+        ExecuteCustomQuery(QueryText, HandlerFunc, -1);
+    }
 
-	void ExecuteCustomQuery(const FString &QueryText, QueryResultHandler HandlerFunc, int32 TakeLimit)
-	{
-		if (!IsInitialized)
-		{
-			Initialize();
-		}
+    void ExecuteCustomQuery(const FString &QueryText, QueryResultHandler HandlerFunc, int32 TakeLimit)
+    {
+        if (!IsInitialized)
+        {
+            Initialize();
+        }
 
-		if (TakeLimit < 0)
-		{
-			TakeLimit = ConfiguredTakeLimit;
-		}
+        if (TakeLimit < 0)
+        {
+            TakeLimit = ConfiguredTakeLimit;
+        }
 
-		FHttpRequestPtr Request = CreateRequest(HandlerFunc, TakeLimit);
-		Request->SetVerb(TEXT("POST"));
-		Request->SetContentAsString(QueryText);
-		Request->ProcessRequest();
-	}
+        FHttpRequestPtr Request = CreateRequest(HandlerFunc, TakeLimit);
+        Request->SetVerb(TEXT("POST"));
+        Request->SetContentAsString(QueryText);
+        Request->ProcessRequest();
+    }
 
-	void ExecuteCustomQuery(QueryResultHandler HandlerFunc)
-	{
-		ExecuteDefaultQuery(HandlerFunc, -1);
-	}
+    void ExecuteCustomQuery(QueryResultHandler HandlerFunc)
+    {
+        ExecuteDefaultQuery(HandlerFunc, -1);
+    }
 
-	void ExecuteDefaultQuery(QueryResultHandler HandlerFunc, int32 TakeLimit)
-	{
-		if (!IsInitialized)
-		{
-			Initialize();
-		}
+    void ExecuteDefaultQuery(QueryResultHandler HandlerFunc, int32 TakeLimit)
+    {
+        if (!IsInitialized)
+        {
+            Initialize();
+        }
 
-		if (TakeLimit < 0)
-		{
-			TakeLimit = ConfiguredTakeLimit;
-		}
+        if (TakeLimit < 0)
+        {
+            TakeLimit = ConfiguredTakeLimit;
+        }
 
-		FHttpRequestPtr Request = CreateRequest(HandlerFunc, TakeLimit);
-		Request->SetVerb(TEXT("GET"));
-		Request->ProcessRequest();
-	}
-
-private:
-	FHttpRequestPtr CreateRequest(QueryResultHandler HandlerFunc, int32 TakeLimit)
-	{
-		auto Request = FTelemetryService::CreateServiceRequest();
-
-		FString Url = FString::Printf(TEXT("%s?take=%i"), *QueryUrl, TakeLimit);
-
-		Request->SetURL(Url);
-		Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
-		Request->SetHeader(TEXT("User-Agent"), "X-UnrealEngine-Agent");
-
-		Request->OnProcessRequestComplete().BindLambda([HandlerFunc](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
-		{
-			if (bWasSuccessful)
-			{
-				TSharedPtr<SQueryResult> Result = SQueryResult::Parse(Response->GetContentAsString());
-
-				HandlerFunc.ExecuteIfBound(Result);
-			}
-		});
-
-		return Request;
-	}
-
-	void Initialize()
-	{
-		const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
-		const FString SectionName = "GameTelemetry";
-
-		GConfig->GetString(*SectionName, TEXT("QueryUrl"), QueryUrl, IniName);
-		if (!GConfig->GetInt(*SectionName, TEXT("QueryTakeLimit"), ConfiguredTakeLimit, IniName))
-		{
-			ConfiguredTakeLimit = DefaultTakeLimit;
-		}
-
-		IsInitialized = true;
-	}
+        FHttpRequestPtr Request = CreateRequest(HandlerFunc, TakeLimit);
+        Request->SetVerb(TEXT("GET"));
+        Request->ProcessRequest();
+    }
 
 private:
-	FString QueryUrl;
+    FHttpRequestPtr CreateRequest(QueryResultHandler HandlerFunc, int32 TakeLimit)
+    {
+        auto Request = FTelemetryService::CreateServiceRequest();
 
-	bool IsInitialized;
-	int32 ConfiguredTakeLimit;
+        FString Url = FString::Printf(TEXT("%s?take=%i"), *QueryUrl, TakeLimit);
 
-	// Default max number of documents to retrieve from the server
-	static const int32 DefaultTakeLimit = 10000;
+        Request->SetURL(Url);
+        Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+        Request->SetHeader(TEXT("User-Agent"), "X-UnrealEngine-Agent");
+
+        Request->OnProcessRequestComplete().BindLambda([HandlerFunc](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+        {
+            if (bWasSuccessful)
+            {
+                TSharedPtr<SQueryResult> Result = SQueryResult::Parse(Response->GetContentAsString());
+
+                HandlerFunc.ExecuteIfBound(Result);
+            }
+        });
+
+        return Request;
+    }
+
+    void Initialize()
+    {
+        const FString IniName = FString::Printf(TEXT("%sGameTelemetry.ini"), *FPaths::SourceConfigDir());
+        const FString SectionName = "GameTelemetry";
+
+        GConfig->GetString(*SectionName, TEXT("QueryUrl"), QueryUrl, IniName);
+        if (!GConfig->GetInt(*SectionName, TEXT("QueryTakeLimit"), ConfiguredTakeLimit, IniName))
+        {
+            ConfiguredTakeLimit = DefaultTakeLimit;
+        }
+
+        IsInitialized = true;
+    }
+
+private:
+    FString QueryUrl;
+
+    bool IsInitialized;
+    int32 ConfiguredTakeLimit;
+
+    // Default max number of documents to retrieve from the server
+    static const int32 DefaultTakeLimit = 10000;
 };

--- a/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/TelemetryVisualizerModule.h
+++ b/Plugins/GameTelemetry/Source/GameTelemetryVisualizer/Public/TelemetryVisualizerModule.h
@@ -18,13 +18,13 @@ class ITelemetryEngine;
 class FTelemetryVisualizerUI;
 
 class FTelemetryVisualizerModule :
-	public IModuleInterface
+    public IModuleInterface
 {
 public:
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
 
 private:
-	TUniquePtr<FTelemetryVisualizerUI> EditorUI;
+    TUniquePtr<FTelemetryVisualizerUI> EditorUI;
 };
 

--- a/docs/UE4_Instructions.md
+++ b/docs/UE4_Instructions.md
@@ -114,14 +114,7 @@ FTelemetry::Position(Pawn->GetActorLocation())
 FTelemetry::Orientation(rotator.Vector())
 ```
 
-2.	If your event has related data that can be used by the heatmap generator (or that you would like attached to each event drawn), a “disp_val” property is needed to direct what event value is needed:
-
-Example:
-```cpp
-FTelemetry::DisplayValue(L”val_health”)
-```
-
-3.	The value that “disp_val” uses will also need to be populated
+2.	Provide data that you would like to view
 
     + For percentages, either prefix your property with “pct_” or use the construction shortcut Percentage.  This will let the visualizer know that the value is a float between 0 and 100.
    
@@ -143,8 +136,7 @@ FTelemetryBuilder Builder;
 Builder.SetProperties({
 	FTelemetry::Position(Pawn->GetActorLocation()),
 	FTelemetry::Orientation(rotator.Vector()),
-	FTelemetry::Value(L"health", MyHealth),
-        FTelemetry::DisplayValue(L”val_health”)
+	FTelemetry::Value(L"health", MyHealth)
 	});
 
 FTelemetry::Record(L”Health”, L”Gameplay”, L”1.3”, MoveTemp(Builder));
@@ -189,13 +181,14 @@ Once you have data uploaded, you are ready to start visualizing it!
 
     ![alt text](\images\heatmap.png)
 
-11. Type represents the type of heatmap you would like to generate.
+11. Value is what values within the events to use to generate the heatmap.
+12. Type represents the type of heatmap you would like to generate.
     + *Population* combines events into physical groups and displays a heatmap of the number of each event within a given group.
     + *Population - Bar* does the same, but generates a 3D bar graph over the XY plane.
     + *Value* also combines events into physical groups, but displays a heatmap of the average of the value of each event within a given group.
     + *Value - Bar* provides a 3D bar graph of value information.
-12. Shape and shape size represent the shape of the heatmap elements along with their radius.  The smaller the radius, the more detailed the information (though also the more complex the heatmap is to generate).
-13. The color range provides the color for the minimum and maximum values in the map.  Colors in between are a fade between the two colors chosen.
-14. Type range will populate when you generate the heatmap, but can be used to adjust the colors.  This can be helpful when your data has outlying values that can cause the heatmap to lack variability.  Adjust the range to remove extreme highs and lows to get more interesting information.
-15. Use Orientation will rotate the heatmap shapes to the average orientation of all events within each element.
-16. Apply to Animation will allow the animation controls above control animating the entire heatmap
+13. Shape and shape size represent the shape of the heatmap elements along with their radius.  The smaller the radius, the more detailed the information (though also the more complex the heatmap is to generate).
+14. The color range provides the color for the minimum and maximum values in the map.  Colors in between are a fade between the two colors chosen.
+15. Type range will populate when you generate the heatmap, but can be used to adjust the colors.  This can be helpful when your data has outlying values that can cause the heatmap to lack variability.  Adjust the range to remove extreme highs and lows to get more interesting information.
+16. Use Orientation will rotate the heatmap shapes to the average orientation of all events within each element.
+17. Apply to Animation will allow the animation controls above control animating the entire heatmap

--- a/docs/UE4_Instructions.md
+++ b/docs/UE4_Instructions.md
@@ -114,7 +114,7 @@ FTelemetry::Position(Pawn->GetActorLocation())
 FTelemetry::Orientation(rotator.Vector())
 ```
 
-2.	Provide data that you would like to view
+2.	Values need specific names in order for the visualizer to recognize them
 
     + For percentages, either prefix your property with “pct_” or use the construction shortcut Percentage.  This will let the visualizer know that the value is a float between 0 and 100.
    
@@ -136,7 +136,7 @@ FTelemetryBuilder Builder;
 Builder.SetProperties({
 	FTelemetry::Position(Pawn->GetActorLocation()),
 	FTelemetry::Orientation(rotator.Vector()),
-	FTelemetry::Value(L"health", MyHealth)
+	FTelemetry::Value(L"health", MyHealth),
 	});
 
 FTelemetry::Record(L”Health”, L”Gameplay”, L”1.3”, MoveTemp(Builder));
@@ -181,7 +181,7 @@ Once you have data uploaded, you are ready to start visualizing it!
 
     ![alt text](\images\heatmap.png)
 
-11. Value is what values within the events to use to generate the heatmap.
+11. Values represents the group of values you would like the heatmap to use.
 12. Type represents the type of heatmap you would like to generate.
     + *Population* combines events into physical groups and displays a heatmap of the number of each event within a given group.
     + *Population - Bar* does the same, but generates a 3D bar graph over the XY plane.


### PR DESCRIPTION
Removing the use of "disp_val" and supporting all values attached to an event. This change requires the following:
- Removing event parsing/construction for disp_val
- Removing percentage check out of the events
- Swapping the actor value to a map of strings for detail display
- Swapping the events to a map of JSON values
- Caching attribute names for each event container
- Adding UI elements to select the value for heatmap generation
- Optimizing the heatmap generation (needed to be done anyway) to offset any additional cost of parsing attribute maps for values rather than using static ones

Also did a whitespace sweep